### PR TITLE
Dynamic Menu System

### DIFF
--- a/components/wtf-drawer-navigation.vue
+++ b/components/wtf-drawer-navigation.vue
@@ -1,19 +1,17 @@
 <template>
-  <v-list>
+  <v-list v-if="$menu('primary')">
     <v-subheader>Navigation</v-subheader>
-    <v-list-item to="/">
+
+    <v-list-item
+      v-for="item of $menu('primary')"
+      :key="item._id"
+      :href="item.type === 'external' ? item.href : null"
+      :to="item.type !== 'external' ? item.href : null"
+    >
       <v-list-item-content>
-        <v-list-item-title>Home</v-list-item-title>
-      </v-list-item-content>
-    </v-list-item>
-    <v-list-item to="/blog">
-      <v-list-item-content>
-        <v-list-item-title>Blog</v-list-item-title>
-      </v-list-item-content>
-    </v-list-item>
-    <v-list-item to="/projects">
-      <v-list-item-content>
-        <v-list-item-title>Projects</v-list-item-title>
+        <v-list-item-title>
+          {{ item.name }}
+        </v-list-item-title>
       </v-list-item-content>
     </v-list-item>
   </v-list>

--- a/components/wtf-navigation.vue
+++ b/components/wtf-navigation.vue
@@ -1,14 +1,8 @@
 <template>
   <div>
-    <v-tabs dark color="white" background-color="transparent">
-      <v-tab to="/">
-        Home
-      </v-tab>
-      <v-tab to="/blog">
-        Blog
-      </v-tab>
-      <v-tab to="/projects">
-        Projects
+    <v-tabs v-if="$menu('primary')" dark color="white" background-color="transparent">
+      <v-tab v-for="item of $menu('primary')" :key="item.name" :href="item.href" :to="item.to">
+        {{ item.name }}
       </v-tab>
     </v-tabs>
   </div>

--- a/components/wtf-navigation.vue
+++ b/components/wtf-navigation.vue
@@ -1,7 +1,12 @@
 <template>
   <div>
     <v-tabs v-if="$menu('primary')" dark color="white" background-color="transparent">
-      <v-tab v-for="item of $menu('primary')" :key="item.name" :href="item.href" :to="item.to">
+      <v-tab
+        v-for="item of $menu('primary')"
+        :key="item._id"
+        :href="item.type === 'external' ? item.href : null"
+        :to="item.type !== 'external' ? item.href : null"
+      >
         {{ item.name }}
       </v-tab>
     </v-tabs>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -82,6 +82,68 @@
           <v-container>
             <nuxt />
           </v-container>
+
+          <v-container>
+            <v-row>
+              <v-col
+                cols="12"
+                md="4"
+              >
+                <v-list v-if="$menu('footer-1')">
+                  <v-list-item
+                    v-for="item of $menu('footer-1')"
+                    :key="item._id"
+                    :href="item.type === 'external' ? item.href : null"
+                    :to="item.type !== 'external' ? item.href : null"
+                  >
+                    <v-list-item-content>
+                      <v-list-item-title>
+                        {{ item.name }}
+                      </v-list-item-title>
+                    </v-list-item-content>
+                  </v-list-item>
+                </v-list>
+              </v-col>
+              <v-col
+                cols="12"
+                md="4"
+              >
+                <v-list v-if="$menu('footer-2')">
+                  <v-list-item
+                    v-for="item of $menu('footer-2')"
+                    :key="item._id"
+                    :href="item.type === 'external' ? item.href : null"
+                    :to="item.type !== 'external' ? item.href : null"
+                  >
+                    <v-list-item-content>
+                      <v-list-item-title>
+                        {{ item.name }}
+                      </v-list-item-title>
+                    </v-list-item-content>
+                  </v-list-item>
+                </v-list>
+              </v-col>
+              <v-col
+                cols="12"
+                md="4"
+              >
+                <v-list v-if="$menu('footer-3')">
+                  <v-list-item
+                    v-for="item of $menu('footer-3')"
+                    :key="item._id"
+                    :href="item.type === 'external' ? item.href : null"
+                    :to="item.type !== 'external' ? item.href : null"
+                  >
+                    <v-list-item-content>
+                      <v-list-item-title>
+                        {{ item.name }}
+                      </v-list-item-title>
+                    </v-list-item-content>
+                  </v-list-item>
+                </v-list>
+              </v-col>
+            </v-row>
+          </v-container>
         </v-sheet>
       </v-container>
     </v-content>

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,39 +1,31 @@
 <template>
   <div>
+    <h1 class="display-3 text-center">What the fuck?</h1>
+
     <div v-if="error.statusCode">
-      <v-row align="center" justify="center">
-        <v-img v-if="settings.httpStatusCodeCats" :src="`https://http.cat/${error.statusCode}`" />
-        <h1 v-else class="text-center display-4">
-          {{ error.statusCode }}
-        </h1>
-      </v-row>
-      <v-row align="center" justify="center">
-        <p v-if="error.message" class="text-center">
-          {{ error.message }}
-        </p>
-      </v-row>
-      <v-row align="center" justify="center">
-        <p v-if="error.statusCode === 403" class="text-center secondary--text">
-          I'm sorry Dave, but I'm afraid I can't let you do that.
-        </p>
-        <p v-else class="text-center secondary--text">
-          I do believe that this is, in fact, an error.
-        </p>
-      </v-row>
+      <v-img v-if="settings.enableErrorCats" :src="`https://http.cat/${error.statusCode}`" />
+      <h1 v-else class="display-1 text-center">HTTP {{ error.statusCode }}</h1>
     </div>
-    <v-row v-else align="center" justify="center">
-      <h1 class="display-4 text-center">
-        Awww fucking hell.
-      </h1>
-      <p class="text-center">
-        An unknown error has occurred. Probably another god damn bug.
-      </p>
-    </v-row>
-    <v-row align="center" justify="center">
-      <v-btn text to="/">
-        Go home
-      </v-btn>
-    </v-row>
+
+    <v-divider />
+
+    <v-card>
+      <v-list-item two-line>
+        <v-list-item-content>
+          <v-list-item-title class="overline">
+            Error details
+          </v-list-item-title>
+          <v-list-item-subtitle class="title">{{ error.message }}</v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+
+      <v-list-item v-if="error.stack" two-line>
+        <v-list-item-content>
+          <v-list-item-title class="overline">Stack trace</v-list-item-title>
+          <v-list-item-subtitle>{{ error.stack }}</v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+    </v-card>
   </div>
 </template>
 

--- a/middleware/menu.js
+++ b/middleware/menu.js
@@ -1,0 +1,10 @@
+export default async function (context) {
+  try {
+    const menuInfo = await context.app.$axios.get('/api/menu')
+    const manifest = await context.app.$axios.get('/api/theme')
+
+    context.store.commit('menu/update', { manifest: manifest.data, menuSystem: menuInfo.data })
+  } catch (err) {
+    context.error(err)
+  }
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -4,6 +4,7 @@ module.exports = {
   mode: 'spa',
   router: {
     middleware: [
+      'menu',
       'setup'
     ]
   },
@@ -100,6 +101,7 @@ module.exports = {
   ** Plugins to load before mounting the App
   */
   plugins: [
+    { src: '~/plugins/menu.js', ssr: false },
     { src: '~/plugins/localStorage.js', ssr: false },
     { src: '~/plugins/wtf-core.js', ssr: false },
     { src: '~/plugins/markdown.js', ssr: false }

--- a/pages/admin/menus.vue
+++ b/pages/admin/menus.vue
@@ -35,12 +35,28 @@
           </v-list-item>
 
           <v-list v-if="$menu(slot.slot)">
-            <v-list-item v-for="item of $menu(slot.slot)" :key="item.name">
+            <v-list-item v-for="item of $menu(slot.slot)" :key="item._id">
+              <v-list-item-icon>
+                <v-icon>mdi-menu</v-icon>
+              </v-list-item-icon>
+
               <v-list-item-content>
                 <v-list-item-title>
                   {{ item.name }}
                 </v-list-item-title>
+                <v-list-item-subtitle>
+                  <code>{{ item.type }}</code>
+                  &bull;
+                  <v-icon small>
+                    mdi-link
+                  </v-icon>
+                  <code>{{ item.href }}</code>
+                </v-list-item-subtitle>
               </v-list-item-content>
+
+              <v-btn v-if="$auth.user.owner" icon @click="showDelete(item._id)">
+                <v-icon>mdi-delete</v-icon>
+              </v-btn>
             </v-list-item>
           </v-list>
           <v-card-text v-else>
@@ -50,6 +66,31 @@
         </v-card>
       </v-col>
     </v-row>
+
+    <v-dialog v-if="$auth.user.owner" v-model="deleteIsOpen" persistent width="600">
+      <v-card>
+        <v-card-title class="title">
+          Delete menu item
+        </v-card-title>
+
+        <v-card-text>
+          Are you sure you want to delete this menu item?
+        </v-card-text>
+
+        <v-divider />
+
+        <v-card-actions>
+          <v-spacer />
+
+          <v-btn text @click="deleteIsOpen = ''">
+            Nope
+          </v-btn>
+          <v-btn text color="primary" @click="deleteItem">
+            Yeah, sure, whatever.
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
 
     <v-dialog v-if="$auth.user.owner" v-model="creating" persistent width="750">
       <template v-slot:activator="{ on }">
@@ -155,6 +196,8 @@
 export default {
   data () {
     return {
+      deleteIsOpen: false,
+      deleteId: '',
       nameError: '',
       linkError: '',
       typeError: '',
@@ -221,6 +264,21 @@ export default {
       })
   },
   methods: {
+    showDelete (id) {
+      this.deleteIsOpen = true
+      this.deleteId = id
+    },
+    deleteItem () {
+      this.$axios.post(`/api/menu/${this.deleteId}/delete`, {})
+        .then((res) => {
+          this.$store.commit('menu/deleteItem', this.deleteId)
+          this.deleteId = ''
+          this.deleteIsOpen = false
+          this.$router.replace('/admin/menus')
+        }).catch((err) => {
+          alert(err)
+        })
+    },
     createMenuItem () {
       this.creating = true
     },
@@ -278,3 +336,9 @@ export default {
   }
 }
 </script>
+
+<style>
+code {
+  background: transparent !important;
+}
+</style>

--- a/pages/admin/menus.vue
+++ b/pages/admin/menus.vue
@@ -1,0 +1,280 @@
+<template>
+  <div>
+    <v-card-title class="display-1">
+      Menus
+    </v-card-title>
+
+    <v-card-subtitle>
+      Menus are different places on the page for you to place navigation links to
+      <nuxt-link to="/admin/pages">
+        Pages
+      </nuxt-link>
+      and external websites. Themes will provide different locations, called menu slots, for items to be placed. Your current theme ({{ theme.name }}) has {{ themeSlots }} available.
+    </v-card-subtitle>
+    <v-card-subtitle>
+      This page allows you to create, edit, and remove menu items.  If no menu items are in a slot, the theme will not show the slot on the page.
+    </v-card-subtitle>
+
+    <v-divider />
+
+    <v-row>
+      <v-col v-for="slot of theme.menus" cols="12" md="6" :key="slot.slot">
+        <v-card raised>
+          <v-list-item three-line>
+            <v-list-item-content>
+              <v-list-item-title class="overline">
+                {{ slot.slot }} ({{ theme.name}} Menu Slot)
+              </v-list-item-title>
+              <v-list-item-subtitle class="title">
+                {{ slot.name }}
+              </v-list-item-subtitle>
+              <v-list-item-subtitle>
+                {{ slot.description }}
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
+
+          <v-list v-if="$menu(slot.slot)">
+            <v-list-item v-for="item of $menu(slot.slot)" :key="item.name">
+              <v-list-item-content>
+                <v-list-item-title>
+                  {{ item.name }}
+                </v-list-item-title>
+              </v-list-item-content>
+            </v-list-item>
+          </v-list>
+          <v-card-text v-else>
+              This slot has no menu items in it.  The slot will not display on the page until at least one
+              item is added.
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <v-dialog v-if="$auth.user.owner" v-model="creating" persistent width="750">
+      <template v-slot:activator="{ on }">
+        <v-btn
+          color="primary"
+          fab
+          fixed
+          bottom
+          right
+          v-on="on"
+        >
+          <v-icon>mdi-plus</v-icon>
+        </v-btn>
+      </template>
+
+      <v-card>
+        <v-card-title class="title">
+          Create menu item
+        </v-card-title>
+
+        <v-card-text>
+          <v-text-field v-model="menuitem.name" label="Name" :error-messages="nameError" />
+
+          <v-row>
+            <v-col
+              cols="6"
+            >
+              <v-select
+                v-model="menuitem.slot"
+                :items="theme.menus"
+                item-text="name"
+                item-value="slot"
+                label="Menu slot"
+                :error-messages="slotError"
+              />
+            </v-col>
+            <v-col
+              cols="6"
+            >
+              <v-select
+                v-model="menuitem.type"
+                :items="menuitemtypes"
+                item-text="name"
+                item-value="value"
+                label="Item type"
+                :error-messages="typeError"
+              />
+            </v-col>
+          </v-row>
+
+          <div v-if="menuitem.type === 'page'">
+            <v-select
+              v-model="menuitem.page"
+              :items="pages"
+              item-text="name"
+              item-value="_id"
+              label="Page"
+              :disabled="pages.length < 2"
+              :error-messages="linkError"
+            />
+
+            <p v-if="pages.length < 2">
+              Your website doesn't have any Pages yet, so you cannot use this menu item type.
+            </p>
+          </div>
+          <div v-if="menuitem.type === 'post'">
+            <v-select
+              v-model="menuitem.post"
+              :items="posts"
+              item-text="name"
+              item-value="_id"
+              label="Blog post"
+              :disabled="posts.length < 2"
+              :error-messages="linkError"
+            />
+
+            <p v-if="posts.length < 2">
+              Your website doesn't have any blog posts yet, so you cannot use this menu item type.
+            </p>
+          </div>
+          <div v-if="menuitem.type === 'external'">
+            <v-text-field v-model="menuitem.href" label="External link" :error-messages="linkError" />
+          </div>
+        </v-card-text>
+
+        <v-divider />
+
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text @click="creating = false">
+            Cancel
+          </v-btn>
+          <v-btn text color="primary" @click="submitMenuItem">
+            Create
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      nameError: '',
+      linkError: '',
+      typeError: '',
+      slotError: '',
+      creating: false,
+      menuitem: {
+        name: '',
+        slot: '',
+        page: '',
+        post: '',
+        href: '',
+        type: 'page'
+      },
+      pages: [],
+      posts: [],
+      menuitemtypes: [
+        {
+          name: 'Page',
+          value: 'page'
+        },
+        {
+          name: 'Post',
+          value: 'post'
+        },
+        {
+          name: 'External link',
+          value: 'external'
+        }
+      ]
+    }
+  },
+  computed: {
+    theme () {
+      return this.$store.state.menu.theme
+    },
+    themeSlots () {
+      if (this.theme.menus.length > 1) {
+        return `${this.theme.menus.length} menu slots`
+      } else if (this.theme.menu.length === 1) {
+        return 'a single menu slot'
+      } else {
+        return 'no menu slots'
+      }
+    }
+  },
+  mounted () {
+    this.$axios.get('/api/posts')
+      .then((res) => {
+        this.posts = res.data
+        this.posts.unshift({
+          _id: '',
+          name: 'Choose blog post'
+        })
+
+        return this.$axios.get('/api/pages')
+      }).then((res) => {
+        this.pages = res.data
+        this.pages.unshift({
+          _id: '',
+          name: 'Choose page'
+        })
+      }).catch((err) => {
+        this.$nuxt.error(err)
+      })
+  },
+  methods: {
+    createMenuItem () {
+      this.creating = true
+    },
+    validateMenuItem () {
+      this.linkError = ''
+      this.nameError = ''
+      this.slotError = ''
+      this.typeError = ''
+
+      if (this.menuitem.name.trim()) {
+        if (this.menuitem.slot) {
+          switch (this.menuitem.type) {
+            case 'page':
+              if (!this.menuitem.page) {
+                this.linkError = 'Please select a page.'
+                return false
+              }
+              return true
+            case 'post':
+              if (!this.menuitem.post) {
+                this.linkError = 'Please select a blog post.'
+                return false
+              }
+              return true
+            case 'external':
+              if (!this.menuitem.href.trim()) {
+                this.linkError = 'Please enter a valid external link.'
+                return false
+              }
+              return true
+            default:
+              this.typeError = 'Unknown menu item type.'
+              return false
+          }
+        } else {
+          this.slotError = 'Please select a menu slot.'
+          return false
+        }
+      } else {
+        this.nameError = 'Menu item must have a non-empty name.'
+        return false
+      }
+    },
+    submitMenuItem () {
+      if (this.validateMenuItem()) {
+        this.$axios.post('/api/menu', this.menuitem)
+          .then((res) => {
+            this.$store.commit('menu/addItem', res.data)
+            this.creating = false
+          }).catch((err) => {
+            this.$nuxt.error(err)
+          })
+      }
+    }
+  }
+}
+</script>

--- a/plugins/menu.js
+++ b/plugins/menu.js
@@ -1,0 +1,5 @@
+export default (context, inject) => {
+  inject('menu', (slot) => {
+    return context.store.state.menu.menus[slot] || []
+  })
+}

--- a/plugins/menu.js
+++ b/plugins/menu.js
@@ -1,5 +1,10 @@
 export default (context, inject) => {
   inject('menu', (slot) => {
-    return context.store.state.menu.menus[slot] || []
+    const items = context.store.state.menu.menus[slot]
+    if (items && items.length) {
+      return items
+    } else {
+      return false
+    }
   })
 }

--- a/server/index.js
+++ b/server/index.js
@@ -73,12 +73,33 @@ async function start (siteSettings) {
   })
 }
 
+async function createDefaultMenuItems () {
+  const MenuItem = require('./models/menuitem')
+  const Page = require('./models/page')
+
+  const systemPages = await Page.find({ system: true })
+
+  for (let page of pages) {
+    const exists = await MenuItem.findOne({ name: page.Name, page: page._id, type: 'page' })
+    if  (!exists) {
+      const menuItem = new MenuItem({
+        name: page.name,
+        slot: 'primary',
+        page: page._id,
+        type: 'page'
+      })
+      await menuItem.save()
+    }
+  }
+}
+
 async function ensureSiteSettingsExist () {
   const sitesettings = SiteSetting.findOne({})
   if (sitesettings) {
     return sitesettings
   } else {
     const newSettings = new siteSetting({})
+    await createDefaultMenuItems()
     return await newSettings.save()
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,7 @@ async function start (siteSettings) {
   const authRoute = require('./routes/auth')
   const PagesRouter = require('./routes/pages')
   const PageRouter = require('./routes/page')
+  const ThemeRouter = require('./routes/theme')
 
   await nuxt.ready()
   // Build only in dev mode
@@ -44,6 +45,7 @@ async function start (siteSettings) {
   app.use('/api/auth', authRoute)
   app.use('/api/pages', PagesRouter)
   app.use('/api/page', PageRouter)
+  app.use('/api/theme', ThemeRouter)
 
   // Give nuxt middle`ware to express
   app.use(nuxt.render)

--- a/server/index.js
+++ b/server/index.js
@@ -5,12 +5,25 @@ const app = express()
 const mongoose = require('mongoose');
 const bodyParser = require('body-parser');
 const SiteSetting = require('./models/sitesetting')
+const fs = require('fs')
+const path = require('path')
+
+const themesPath = path.join(__dirname, '..', 'themes')
+const themePath = path.join(themesPath, 'material')
+const themeManifestPath = path.join(themePath, 'manifest.json')
 
 require('dotenv').config()
+
+
 
 // Import and Set Nuxt.js options
 const config = require('../nuxt.config.js')
 config.dev = process.env.NODE_ENV !== 'production'
+
+// read and parse the theme manifest.
+const theme = JSON.parse(fs.readFileSync(themeManifestPath))
+
+app.locals.theme = theme
 
 async function start (siteSettings) {
   // Init Nuxt.js
@@ -26,6 +39,7 @@ async function start (siteSettings) {
   const PagesRouter = require('./routes/pages')
   const PageRouter = require('./routes/page')
   const ThemeRouter = require('./routes/theme')
+  const MenuRouter = require('./routes/menu')
 
   await nuxt.ready()
   // Build only in dev mode
@@ -46,6 +60,7 @@ async function start (siteSettings) {
   app.use('/api/pages', PagesRouter)
   app.use('/api/page', PageRouter)
   app.use('/api/theme', ThemeRouter)
+  app.use('/api/menu', MenuRouter)
 
   // Give nuxt middle`ware to express
   app.use(nuxt.render)

--- a/server/models/menuitem.js
+++ b/server/models/menuitem.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose')
+
+const { Schema } = mongoose
+
+const MenuItemSchema = new Schema({
+  title: { type: String, required: true },
+  to: { type: String, required: false },
+  href: { type: String, required: false },
+  item_type: { type: String, required: true },
+  menu_slot: { type: String, required: false }
+})
+
+module.exports = mongoose.model('menuitem', MenuItemSchema)

--- a/server/models/menuitem.js
+++ b/server/models/menuitem.js
@@ -3,11 +3,12 @@ const mongoose = require('mongoose')
 const { Schema } = mongoose
 
 const MenuItemSchema = new Schema({
-  title: { type: String, required: true },
-  to: { type: String, required: false },
+  name: { type: String, required: true },
   href: { type: String, required: false },
-  item_type: { type: String, required: true },
-  menu_slot: { type: String, required: false }
+  page:  { type: String, required: false },
+  post: { type: String, required: false },
+  type: { type: String, required: true },
+  slot: { type: String, required: false }
 })
 
 module.exports = mongoose.model('menuitem', MenuItemSchema)

--- a/server/models/page.js
+++ b/server/models/page.js
@@ -6,6 +6,7 @@ const PageSchema = new Schema({
   slug: { type: String, required: true },
   name: { type: String, required: true },
   body: String,
+  system: { type: Boolean, required: true, default: false },
   created: { type: Date, required: true },
   edited: { type: Date, required: true },
   parent: { type: Schema.Types.ObjectId, ref: 'page', required: false, default: null }

--- a/server/routes/menu.js
+++ b/server/routes/menu.js
@@ -1,7 +1,86 @@
 const express = require('express')
+const auth = require('../middleware/auth')
 const MenuItem = require('../models/menuitem')
+const Post = require('../models/post')
+const Page = require('../models/page')
 
 const router = express.Router()
+
+function validateMenuLink(type, id, callback) {
+  switch (type) {
+    case 'page':
+      Page.findById(id).exec(function (err, page) {
+        if (err) {
+          callback(err, false)
+        } else if (page) {
+          callback(null, true)
+        } else {
+          callback(null, false)
+        }
+      })
+      break
+    case 'post':
+      Post.findById(id).exec(function (err, post) {
+        if (err) {
+          callback(err, false)
+        } else if (post) {
+          callback(null, true)
+        } else {
+          callback(null, false)
+        }
+      })
+      break;
+    case 'external':
+      if (id.trim()) {
+        callback(null, true)
+      } else {
+        callback(null, false)
+      }
+      break;
+    default:
+      callback(new Error('invalid menu link type.'), false)
+      break;
+  }
+}
+
+async function traversePageTree(id) {
+  const pages = []
+  let descendant = await Page.findById(id)
+  pages.unshift(descendant)
+  while(descendant.parent) {
+    descendant = await Page.findById(descendant.parent)
+    pages.unshift(descendant)
+  }
+  return pages
+}
+
+async function getPageSlug(id) {
+  const parents = await traversePageTree(id)
+  let slug = ''
+  for (const page of parents) {
+    slug += '/'
+    if (page.slug === '<index>') {
+      continue
+    }
+    slug += page.slug
+  }
+  return slug
+}
+
+async function setMenuItemLinks(items) {
+  for (const item of items) {
+    switch (item.type) {
+      case 'post':
+        const post = await Post.findById(item.post)
+        item.href = `/blog/${post.slug}`
+        break;
+      case 'page':
+        item.href = await getPageSlug(item.page)
+        break;
+    }
+  }
+  return items
+}
 
 function getAvailableSlotNames(manifest) {
   const slots = []
@@ -20,9 +99,87 @@ router.get('/', function (req, res) {
         message: err.message
       })
     } else {
-      res.status(200).json(items)
+      setMenuItemLinks(items)
+        .then((items) => {
+          res.status(200).json(items)
+        }).catch((err) => {
+          res.status(500).json({
+            message: err.message
+          })
+        })
     }
   })
+})
+
+router.post('/', auth.owner, function (req, res) {
+  const { name, type, slot, href, page, post } = req.body
+  const slots = getAvailableSlotNames(req.app.locals.theme)
+
+  if (!slots.includes(slot)) {
+    res.status(400).json({
+      message: 'Specified slot not specified by current theme.'
+    })
+  } else {
+    if (!name || !name.trim()) {
+      res.status(400).json({
+        message: 'Menu item name is required.'
+      })
+    } else {
+      let id = href
+      if (type === 'post') id = post
+      if (type === 'page') id = page
+
+      validateMenuLink(type, id, function (err, found) {
+        if (err) {
+          res.status(500).json({
+            message: err.message
+          })
+        } else if (found) {
+          MenuItem.findOne({
+            name,
+            slot
+          }).exec(function (err, exists) {
+            if (err) {
+              res.status(500).json({
+                message: err.message
+              })
+            } else if (exists) {
+              res.status(400).json({
+                message: 'A menu item with this name already exists in the slot.'
+              })
+            } else {
+              const newItem = new MenuItem({
+                name,
+                slot,
+                href,
+                page,
+                post,
+                type
+              })
+
+              newItem.save(function (err, saved) {
+                if (err) {
+                  res.status(500).json({
+                    message: err.message
+                  })
+                } else if (saved) {
+                  res.status(200).json(saved)
+                } else {
+                  res.status(500).json({
+                    message: 'An error has occurred saving the menu item.'
+                  })
+                }
+              })
+            }
+          })
+        } else {
+          res.status(404).json({
+            message: 'Either a valid Post or Page was not found, or the given external link for the menu item was blank.'
+          })
+        }
+      })
+    }
+  }
 })
 
 router.get('/:slot', function (req, res) {
@@ -35,11 +192,18 @@ router.get('/:slot', function (req, res) {
     } else {
       const response = []
       for (let item of menuItems) {
-        if (item.menu_slot === req.params.slot || (req.params.slot === 'primary' && !menuSlots.includes(item.menu_slot))) {
+        if (item.slot === req.params.slot || (req.params.slot === 'primary' && !menuSlots.includes(item.slot))) {
           response.push(item.toJSON())
         }
       }
-      res.status(200).json(response)
+      setMenuItemLinks(response)
+        .then((items) => {
+          res.status(200).json(items)
+        }).catch((err) => {
+          res.status(500).json({
+            message: err.message
+          })
+        })
     }
   })
 })

--- a/server/routes/menu.js
+++ b/server/routes/menu.js
@@ -1,0 +1,47 @@
+const express = require('express')
+const MenuItem = require('../models/menuitem')
+
+const router = express.Router()
+
+function getAvailableSlotNames(manifest) {
+  const slots = []
+  for (let slot of manifest.menus) {
+    if (!slots.includes(slot.slot)) {
+      slots.push(slot.slot)
+    }
+  }
+  return slots
+}
+
+router.get('/', function (req, res) {
+  MenuItem.find({}).exec(function (err, items) {
+    if (err) {
+      res.status(500).json({
+        message: err.message
+      })
+    } else {
+      res.status(200).json(items)
+    }
+  })
+})
+
+router.get('/:slot', function (req, res) {
+  const menuSlots = getAvailableSlotNames(req.app.locals.theme)
+  MenuItem.find({}).exec(function (err, menuItems) {
+    if (err) {
+      res.status(500).json({
+        message: err.message
+      })
+    } else {
+      const response = []
+      for (let item of menuItems) {
+        if (item.menu_slot === req.params.slot || (req.params.slot === 'primary' && !menuSlots.includes(item.menu_slot))) {
+          response.push(item.toJSON())
+        }
+      }
+      res.status(200).json(response)
+    }
+  })
+})
+
+module.exports = router

--- a/server/routes/menu.js
+++ b/server/routes/menu.js
@@ -195,30 +195,4 @@ router.post('/', auth.owner, function (req, res) {
   }
 })
 
-router.get('/:slot', function (req, res) {
-  const menuSlots = getAvailableSlotNames(req.app.locals.theme)
-  MenuItem.find({}).exec(function (err, menuItems) {
-    if (err) {
-      res.status(500).json({
-        message: err.message
-      })
-    } else {
-      const response = []
-      for (let item of menuItems) {
-        if (item.slot === req.params.slot || (req.params.slot === 'primary' && !menuSlots.includes(item.slot))) {
-          response.push(item.toJSON())
-        }
-      }
-      setMenuItemLinks(response)
-        .then((items) => {
-          res.status(200).json(items)
-        }).catch((err) => {
-          res.status(500).json({
-            message: err.message
-          })
-        })
-    }
-  })
-})
-
 module.exports = router

--- a/server/routes/menu.js
+++ b/server/routes/menu.js
@@ -195,4 +195,53 @@ router.post('/', auth.owner, function (req, res) {
   }
 })
 
+router.get('/:id', function (req, res) {
+  MenuItem.findById(req.params.id).exec(function (err, item) {
+    if (err) {
+      res.status(500).json({
+        message: err.message
+      })
+    } else if (item) {
+      setMenuItemLink(item)
+        .then((item) => {
+          res.status(200).json(item)
+        }).catch((err) => {
+          res.status(500).json({
+            message: err.message
+          })
+        })
+    } else {
+      res.status(404).json({
+        message: 'Menu item not found.'
+      })
+    }
+  })
+})
+
+router.post('/:id/delete', auth.owner, function (req, res) {
+  MenuItem.findById(req.params.id).exec(function (err, item) {
+    if (err) {
+      res.status(500).json({
+        message: err.message
+      })
+    } else if (item) {
+      MenuItem.deleteOne(item).exec(function (err, deleted) {
+        if (err) {
+          res.status(500).json({
+            message: err.message
+          })
+        } else {
+          res.status(200).json({
+            message: 'Menu item deleted successfully.'
+          })
+        }
+      })
+    } else {
+      res.status(404).json({
+        message: 'Menu item not found.'
+      })
+    }
+  })
+})
+
 module.exports = router

--- a/server/routes/theme.js
+++ b/server/routes/theme.js
@@ -1,0 +1,49 @@
+const express = require('express')
+const router = express.Router()
+
+// Themes are not yet implemented.  However, for the menu system, we
+// need a way to tell the frontend and admin panel about the current wtf-pwa
+// "theme" and thus the menu slots that are available to the Menu System.
+//
+// In the future, it will be up to each individual theme to write a Theme Manifest
+// and up to us as an API to know what the active theme is and provide the manifest
+// to the frontend.  It is also up to us to serve the right Nuxt layouts/components
+// and configs based on what theme is active.
+//
+// For now, this is a hardcoded json theme manifest. It's fake.
+const hardcodedThemeManifest = {
+  name: 'Material Design',
+  author: 'Alkaline Thunder',
+  system: true,
+  description: 'Mobile-friendly Material Design theme for wtf-pwa written using Vuetify.  Supports dark theme toggle and responsive layout for desktop and mobile.  This is the default system layout.',
+  supportsDarkMode: true,
+  menus: [
+    {
+      slot: 'primary',
+      name: 'Primary Navigation',
+      description: 'The navigation menu shown in the page header area (desktop) and App Drawer (mobile).'
+    },
+    {
+      slot: 'footer-1',
+      name: 'Footer 1',
+      description: 'A vertical navigation menu displayed on the left side of the footer.'
+    },
+    {
+      slot: 'footer-2',
+      name: 'Footer 2',
+      description: 'A vertical navigation menu displayed in the middle of the footer.'
+    },
+    {
+      slot: 'footer-3',
+      name: 'Footer 3',
+      description: 'A vertical navigation menu displayed on the right side of the footer.'
+    }
+  ],
+  prismTheme: 'prism-twilight'
+}
+
+router.get('/', function (req, res) {
+  res.status(200).json(hardcodedThemeManifest)
+})
+
+module.exports = router

--- a/server/routes/theme.js
+++ b/server/routes/theme.js
@@ -1,49 +1,8 @@
 const express = require('express')
 const router = express.Router()
 
-// Themes are not yet implemented.  However, for the menu system, we
-// need a way to tell the frontend and admin panel about the current wtf-pwa
-// "theme" and thus the menu slots that are available to the Menu System.
-//
-// In the future, it will be up to each individual theme to write a Theme Manifest
-// and up to us as an API to know what the active theme is and provide the manifest
-// to the frontend.  It is also up to us to serve the right Nuxt layouts/components
-// and configs based on what theme is active.
-//
-// For now, this is a hardcoded json theme manifest. It's fake.
-const hardcodedThemeManifest = {
-  name: 'Material Design',
-  author: 'Alkaline Thunder',
-  system: true,
-  description: 'Mobile-friendly Material Design theme for wtf-pwa written using Vuetify.  Supports dark theme toggle and responsive layout for desktop and mobile.  This is the default system layout.',
-  supportsDarkMode: true,
-  menus: [
-    {
-      slot: 'primary',
-      name: 'Primary Navigation',
-      description: 'The navigation menu shown in the page header area (desktop) and App Drawer (mobile).'
-    },
-    {
-      slot: 'footer-1',
-      name: 'Footer 1',
-      description: 'A vertical navigation menu displayed on the left side of the footer.'
-    },
-    {
-      slot: 'footer-2',
-      name: 'Footer 2',
-      description: 'A vertical navigation menu displayed in the middle of the footer.'
-    },
-    {
-      slot: 'footer-3',
-      name: 'Footer 3',
-      description: 'A vertical navigation menu displayed on the right side of the footer.'
-    }
-  ],
-  prismTheme: 'prism-twilight'
-}
-
 router.get('/', function (req, res) {
-  res.status(200).json(hardcodedThemeManifest)
+  res.status(200).json(req.app.locals.theme)
 })
 
 module.exports = router

--- a/store/menu.js
+++ b/store/menu.js
@@ -1,3 +1,5 @@
+import Vue from 'vue'
+
 export const state = () => {
   return {
     menus: {},
@@ -6,6 +8,14 @@ export const state = () => {
 }
 
 export const mutations = {
+  deleteItem (state, id) {
+    for (const slot of Object.keys(state.menus)) {
+      const index = state.menus[slot].findIndex(x => x._id === id)
+      if (index !== -1) {
+        Vue.set(state.menus, state.menus[slot].splice(index, 1))
+      }
+    }
+  },
   addItem (state, item) {
     if (!(item.slot in state.menus)) {
       state.menus[item.slot] = []

--- a/store/menu.js
+++ b/store/menu.js
@@ -1,0 +1,31 @@
+export const state = () => {
+  return {
+    menus: {}
+  }
+}
+
+export const mutations = {
+  update (state, { manifest, menuSystem }) {
+    alert(manifest)
+    alert(menuSystem)
+
+    state.menus = {}
+
+    for (const menu of manifest.menus) {
+      if (!(menu.slot in state.menus)) {
+        state.menus[menu.slot] = []
+        for (const menuitem of menuSystem) {
+          if (menuitem.slot === menu.slot) {
+            state.menus[menu.slot].push(menuitem)
+          }
+        }
+      }
+    }
+
+    for (const menuItem of menuSystem) {
+      if (!(menuItem.slot in state.menus)) {
+        state.menus.primary.push(menuItem)
+      }
+    }
+  }
+}

--- a/store/menu.js
+++ b/store/menu.js
@@ -1,15 +1,20 @@
 export const state = () => {
   return {
-    menus: {}
+    menus: {},
+    theme: {}
   }
 }
 
 export const mutations = {
+  addItem (state, item) {
+    if (!(item.slot in state.menus)) {
+      state.menus[item.slot] = []
+    }
+    state.menus[item.slot].push(item)
+  },
   update (state, { manifest, menuSystem }) {
-    alert(manifest)
-    alert(menuSystem)
-
     state.menus = {}
+    state.theme = manifest
 
     for (const menu of manifest.menus) {
       if (!(menu.slot in state.menus)) {

--- a/themes/material/manifest.json
+++ b/themes/material/manifest.json
@@ -1,0 +1,30 @@
+{
+  "name": "Material Design",
+  "author": "Alkaline Thunder",
+  "system": true,
+  "description": "Mobile-friendly Material Design theme for wtf-pwa written using Vuetify.  Supports dark theme toggle and responsive layout for desktop and mobile.  This is the default system layout.",
+  "supportsDarkMode": true,
+  "menus": [
+    {
+      "slot": "primary",
+      "name": "Primary Navigation",
+      "description": "The navigation menu shown in the page header area (desktop) and App Drawer (mobile)."
+    },
+    {
+      "slot": "footer-1",
+      "name": "Footer 1",
+      "description": "A vertical navigation menu displayed on the left side of the footer."
+    },
+    {
+      "slot": "footer-2",
+      "name": "Footer 2",
+      "description": "A vertical navigation menu displayed in the middle of the footer."
+    },
+    {
+      "slot": "footer-3",
+      "name": "Footer 3",
+      "description": "A vertical navigation menu displayed on the right side of the footer."
+    }
+  ],
+  "prismTheme": "prism-twilight"
+}


### PR DESCRIPTION
These changes implement support for dynamic menus/navigation in `wtf-pwa` and adds related admin settings and vue layout support.

Todo list:

 - [x] add `menuitem` schema to database
 - [x] allow retrieval of all items in a menu through the rest API
 - [x] allow adding and removing of menu items
 - [x] add "layout manifests" so that the admin UI knows what menus are available as slots
 - [x] allow initial setup to create default menu items for home and blog pages
 - [x] add primary navigation and three footer navigation menus to default layout
 - [x] add a global `$menu` context object to the vue frontend that contains information of all menu items.