### PR TITLE
Editor overhaul

### DIFF
--- a/components/wtf-comment.vue
+++ b/components/wtf-comment.vue
@@ -13,7 +13,7 @@
 
       <p class="body-1">
         {{ text }}
-        <br />
+        <br>
         <a v-if="less !== comment.body" @click="showMore = !showMore">
           {{ showMoreText }}
         </a>
@@ -33,15 +33,15 @@ import moment from 'moment'
 import truncate from 'truncate'
 
 export default {
-  data () {
-    return {
-      showMore: false
-    }
-  },
   props: {
     comment: {
       type: Object,
       default: () => {}
+    }
+  },
+  data () {
+    return {
+      showMore: false
     }
   },
   computed: {

--- a/components/wtf-comment.vue
+++ b/components/wtf-comment.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-flex class="d-flex flex-row mb-4">
+  <v-flex class="d-flex flex-row mb-2 mt-2">
     <v-avatar color="primary" />
     <v-flex class="d-flex flex-column ml-3">
       <v-flex class="d-flex flex-row align-center">
@@ -18,6 +18,12 @@
           {{ showMoreText }}
         </a>
       </p>
+
+      <v-flex class="d-flex flex-row align-center">
+        <slot name="comment-actions" />
+      </v-flex>
+
+      <slot />
     </v-flex>
   </v-flex>
 </template>

--- a/components/wtf-comment.vue
+++ b/components/wtf-comment.vue
@@ -1,24 +1,37 @@
 <template>
-  <v-list-item>
-    <v-list-item-avatar color="primary" />
-    <v-list-item-content>
-      <v-list-item-title>
-        {{ displayname }}
-      </v-list-item-title>
-      <v-list-item-subtitle>
-        {{ comment.body }}
-      </v-list-item-subtitle>
-      <v-list-item-subtitle>
-        <small>{{ timeAgo }}</small>
-      </v-list-item-subtitle>
-    </v-list-item-content>
-  </v-list-item>
+  <v-flex class="d-flex flex-row mb-4">
+    <v-avatar color="primary" />
+    <v-flex class="d-flex flex-column ml-3">
+      <v-flex class="d-flex flex-row align-center">
+        <h4 class="subtitle-2">
+          {{ displayname }}
+        </h4>
+        <small class="caption ml-1">
+          {{ timeAgo }}
+        </small>
+      </v-flex>
+
+      <p class="body-1">
+        {{ text }}
+        <br />
+        <a v-if="less !== comment.body" @click="showMore = !showMore">
+          {{ showMoreText }}
+        </a>
+      </p>
+    </v-flex>
+  </v-flex>
 </template>
 
 <script>
 import moment from 'moment'
+import truncate from 'truncate'
 
 export default {
+  data () {
+    return {
+      showMore: false
+    }
+  },
   props: {
     comment: {
       type: Object,
@@ -26,6 +39,15 @@ export default {
     }
   },
   computed: {
+    showMoreText () {
+      return this.showMore ? 'Show less' : 'Show more'
+    },
+    less () {
+      return truncate(this.comment.body, 120)
+    },
+    text () {
+      return this.showMore ? this.comment.body : this.less
+    },
     displayname () {
       return this.comment.author.displayName || this.comment.author.username
     },

--- a/components/wtf-comments.vue
+++ b/components/wtf-comments.vue
@@ -2,25 +2,26 @@
   <div>
     <div v-if="postId">
       <v-form v-if="$auth.loggedIn" @submit="postComment">
-        <v-card dense>
-          <v-card-text>
+        <v-flex class="d-flex flex-row mb-6 mt-4">
+          <v-avatar color="primary" />
+          <v-flex class="d-flex flex-column justify-start ml-3">
             <v-textarea
               v-model="newComment"
               label="Post a new comment"
-              dense
-              solo
-              flat
-              rows="2"
+              rows="1"
               auto-grow
             />
-          </v-card-text>
-          <v-card-actions>
-            <v-spacer />
-            <v-btn text type="submit" :disabled="!commentValid">
-              Post
-            </v-btn>
-          </v-card-actions>
-        </v-card>
+
+            <v-flex v-if="newComment.length" class="d-flex flex-row align-center">
+              <v-btn color="primary" type="submit" :disabled="!commentValid">
+                Post
+              </v-btn>
+              <v-btn text @click="newComment = ''">
+                Cancel
+              </v-btn>
+            </v-flex>
+          </v-flex>
+        </v-flex>
       </v-form>
     </div>
     <div v-if="value && value.length">

--- a/components/wtf-comments.vue
+++ b/components/wtf-comments.vue
@@ -2,13 +2,25 @@
   <div>
     <div v-if="postId">
       <v-form v-if="$auth.loggedIn" @submit="postComment">
-        <v-text-field v-model="newComment" label="Post a new comment">
-          <template slot="append">
+        <v-card dense>
+          <v-card-text>
+            <v-textarea
+              v-model="newComment"
+              label="Post a new comment"
+              dense
+              solo
+              flat
+              rows="2"
+              auto-grow
+            />
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
             <v-btn text type="submit" :disabled="!commentValid">
               Post
             </v-btn>
-          </template>
-        </v-text-field>
+          </v-card-actions>
+        </v-card>
       </v-form>
     </div>
     <div v-if="value && value.length">

--- a/components/wtf-drawer-user-menu.vue
+++ b/components/wtf-drawer-user-menu.vue
@@ -11,7 +11,7 @@
         </v-list-item-subtitle>
       </v-list-item-content>
 
-      <v-btn v-if="admin" icon to='/' exact>
+      <v-btn v-if="admin" icon to="/" exact>
         <v-icon>mdi-exit-to-app</v-icon>
       </v-btn>
       <v-btn v-else icon to="/auth/logout">

--- a/components/wtf-markdown-editor.vue
+++ b/components/wtf-markdown-editor.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-row>
+    <v-col cols="12" md="6">
+      <v-textarea
+        dense
+        solo
+        flat
+        class="monospace-editor"
+        rows="1"
+        auto-grow
+        :label="labelText"
+        :value="value"
+        @input="$emit('input', $event)"
+      />
+    </v-col>
+    <v-col cols="12" md="6">
+      <h6 class="overline">
+        Preview
+      </h6>
+      <v-divider />
+      <markdown-renderer v-model="value" />
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      markdown: '',
+      labelText: 'Markdown'
+    }
+  },
+  props: {
+    value: {
+      type: String,
+      default () {
+        return this.markdown
+      }
+    },
+    label: {
+      type: String,
+      default () { return this.labelText }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.monospace-editor {
+  font-family: monospace !important;
+}
+</style>

--- a/components/wtf-markdown-editor.vue
+++ b/components/wtf-markdown-editor.vue
@@ -28,11 +28,6 @@
 
 <script>
 export default {
-  data () {
-    return {
-      markdown: ''
-    }
-  },
   props: {
     value: {
       type: String,
@@ -43,6 +38,11 @@ export default {
     label: {
       type: String,
       default: () => 'Enter Markdown text here'
+    }
+  },
+  data () {
+    return {
+      markdown: ''
     }
   }
 }

--- a/components/wtf-markdown-editor.vue
+++ b/components/wtf-markdown-editor.vue
@@ -8,7 +8,7 @@
         class="monospace-editor"
         rows="1"
         auto-grow
-        :label="labelText"
+        :label="label"
         :value="value"
         @input="$emit('input', $event)"
       />
@@ -18,7 +18,10 @@
         Preview
       </h6>
       <v-divider />
-      <markdown-renderer v-model="value" />
+      <markdown-renderer
+        v-if="value"
+        v-model="value"
+      />
     </v-col>
   </v-row>
 </template>
@@ -27,8 +30,7 @@
 export default {
   data () {
     return {
-      markdown: '',
-      labelText: 'Markdown'
+      markdown: ''
     }
   },
   props: {
@@ -40,7 +42,7 @@ export default {
     },
     label: {
       type: String,
-      default () { return this.labelText }
+      default: () => 'Enter Markdown text here'
     }
   }
 }

--- a/components/wtf-page-editor.vue
+++ b/components/wtf-page-editor.vue
@@ -3,6 +3,7 @@
     <v-card-text>
       <v-textarea
         v-model="value.name"
+        v-if="!quick"
         class="display-1"
         dense
         solo
@@ -14,6 +15,7 @@
 
       <v-select
         v-model="value.parent"
+        v-if="!quick"
         :items="parents"
         label="Parent"
         dense
@@ -36,11 +38,27 @@
     >
       <v-icon>mdi-send</v-icon>
     </v-btn>
-    <v-card-actions v-else>
+    <v-divider v-if="!fab" />
+    <v-card-actions v-if="!fab">
+      <v-btn
+        v-if="$auth.loggedIn && $auth.user.owner && quick"
+        text
+        :to="`/admin/pages/${value._id}`"
+      >
+        Full Editor
+      </v-btn>
       <v-spacer />
+      <v-btn
+        v-if="quick"
+        text
+        @click="$emit('canceled')"
+      >
+        Cancel
+      </v-btn>
       <v-btn
         text
         type="submit"
+        color="primary"
       >
         Save
       </v-btn>

--- a/components/wtf-page-editor.vue
+++ b/components/wtf-page-editor.vue
@@ -2,20 +2,21 @@
   <v-form v-if="value" @submit="savePage">
     <v-card-text>
       <v-textarea
-        v-model="value.name"
         v-if="!quick"
+        v-model="value.name"
         class="display-1"
         dense
         solo
         flat
         rows="1"
         auto-grow
+        label="Page title"
         :readonly="value.system"
       />
 
       <v-select
-        v-model="value.parent"
         v-if="!quick"
+        v-model="value.parent"
         :items="parents"
         label="Parent"
         dense

--- a/components/wtf-page-editor.vue
+++ b/components/wtf-page-editor.vue
@@ -108,6 +108,9 @@ export default {
     }
   },
   computed: {
+    id () {
+      return this.value._id
+    },
     saveUrl () {
       if (this.creator) {
         return '/api/pages'
@@ -116,26 +119,46 @@ export default {
       }
     }
   },
+  watch: {
+    id (newValue) {
+      this.fetchParents()
+    }
+  },
   mounted () {
-    this.$axios.get('/api/pages')
-      .then((res) => {
-        this.buildPageTree(res.data, null, 0)
-      })
+    this.fetchParents()
   },
   methods: {
     buildPageTree (pages, parent, indent) {
       for (const page of pages) {
-        if (page.parent === parent) {
-          this.parents.push({
-            value: page._id,
-            text: `${'--'.repeat(indent)} ${page.name}`
-          })
+        if (page._id === this.value._id) {
+          continue
+        }
 
-          if (pages.filter(x => x.parent === page._id).length) {
-            this.buildPageTree(pages, page._id, indent + 1)
+        if (page.parent === parent) {
+          if (!page.system) {
+            this.parents.push({
+              value: page._id,
+              text: `${'--'.repeat(indent)} ${page.name}`
+            })
+
+            if (pages.filter(x => x.parent === page._id).length) {
+              this.buildPageTree(pages, page._id, indent + 1)
+            }
           }
         }
       }
+    },
+    fetchParents () {
+      this.$axios.get('/api/pages')
+        .then((res) => {
+          this.parents = [
+            {
+              value: null,
+              text: 'No parent'
+            }
+          ]
+          this.buildPageTree(res.data, null, 0)
+        })
     },
     savePage (evt) {
       evt.preventDefault()

--- a/components/wtf-page-editor.vue
+++ b/components/wtf-page-editor.vue
@@ -1,42 +1,29 @@
 <template>
   <v-form v-if="value" @submit="savePage">
-    <v-row>
-      <v-col
-        cols="12"
-        md="6"
-      >
-        <v-card-text v-if="!quick">
-          <v-text-field v-model="value.name" label="Page title" />
-        </v-card-text>
+    <v-card-text>
+      <v-textarea
+        v-model="value.name"
+        class="display-1"
+        dense
+        solo
+        flat
+        rows="1"
+        auto-grow
+        :readonly="value.system"
+      />
 
-        <Editor v-model="value.body" mode="editor" />
+      <v-select
+        v-model="value.parent"
+        :items="parents"
+        label="Parent"
+        dense
+        solo
+        flat
+        :disabled="value.system"
+      />
 
-        <v-card-text>
-          <v-select
-            v-model="value.parent"
-            :items="parents"
-            label="Parent"
-          />
-        </v-card-text>
-      </v-col>
-      <v-col
-        cols="12"
-        md="6"
-      >
-        <v-card raised>
-          <v-card-subtitle>PREVIEW</v-card-subtitle>
-          <v-card-title class="display-1">
-            {{ value.name || 'Untitled Page' }}
-          </v-card-title>
-          <v-card-text v-if="value.body">
-            <wtf-renderer v-model="value.body" />
-          </v-card-text>
-          <v-card-text v-else>
-            Start typing to see a live preview of the page.
-          </v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
+      <wtf-markdown-editor v-model="value.body" />
+    </v-card-text>
 
     <v-btn
       v-if="fab"
@@ -86,7 +73,8 @@ export default {
           body: '',
           created: new Date(),
           edited: new Date(),
-          parent: null
+          parent: null,
+          system: false
         }
       }
     }

--- a/components/wtf-page-viewer.vue
+++ b/components/wtf-page-viewer.vue
@@ -30,18 +30,23 @@
     <v-dialog
       v-if="$auth.loggedIn && $auth.user.owner"
       v-model="quickEdit"
+      persistent
+      width="1200"
     >
-      <v-container>
-        <v-card>
-          <v-card-title class="title">
-            Edit {{ editPage.name }}
-          </v-card-title>
+      <v-card>
+        <v-card-title class="title">
+          Edit {{ editPage.name }}
+        </v-card-title>
 
-          <v-divider />
+        <v-divider />
 
-          <wtf-page-editor v-model="editPage" quick @saved="reload" />
-        </v-card>
-      </v-container>
+        <wtf-page-editor
+          v-model="editPage"
+          quick
+          @saved="reload"
+          @canceled="quickEdit = false"
+        />
+      </v-card>
     </v-dialog>
   </div>
 </template>

--- a/components/wtf-page-viewer.vue
+++ b/components/wtf-page-viewer.vue
@@ -1,26 +1,48 @@
 <template>
   <div>
-    <slot name="breadcrumbs">
-      <v-breadcrumbs v-if="breadcrumbs && breadcrumbs.length" :items="breadcrumbs" />
-    </slot>
+    <slot name="append" />
 
-    <slot name="before" />
+    <v-flex class="d-flex flex-row justify-start align-center">
+      <v-flex class="d-flex flex-column mr-auto">
+        <h1 class="display-1">
+          <slot name="title" />
+        </h1>
+        <h2 class="subtitle-1 text--secondary">
+          <slot name="page-information" />
+        </h2>
+      </v-flex>
+      <slot name="breadcrumbs">
+        <v-breadcrumbs v-if="breadcrumbs && breadcrumbs.length" :items="breadcrumbs" />
+      </slot>
+      <slot name="page-actions" />
+    </v-flex>
 
-    <h1 class="display-1">
-      <slot name="title" />
-    </h1>
+    <v-row>
+      <v-col
+        cols="12"
+        md="8"
+      >
+        <slot name="before-content" />
 
-    <slot name="before-content" />
-
-    <slot />
-
-    <slot name="after-content" />
+        <slot />
+      </v-col>
+      <v-col
+        cols="12"
+        md="4"
+      >
+        <slot name="sidebar" />
+      </v-col>
+      <v-col
+        cols="12"
+        md="8"
+      >
+        <slot name="after-content" />
+      </v-col>
+    </v-row>
 
     <slot name="page-footer">
       <v-card-actions>
-        <slot name="page-information" />
         <v-spacer />
-        <slot name="page-actions" />
       </v-card-actions>
     </slot>
 

--- a/components/wtf-page-viewer.vue
+++ b/components/wtf-page-viewer.vue
@@ -1,105 +1,39 @@
 <template>
   <div>
+    <slot name="breadcrumbs">
+      <v-breadcrumbs v-if="breadcrumbs && breadcrumbs.length" :items="breadcrumbs" />
+    </slot>
+
+    <slot name="before" />
+
     <h1 class="display-1">
-      {{ value.name }}
+      <slot name="title" />
     </h1>
 
-    <p class="body-2">
-      <wtf-renderer
-        v-if="value.body"
-        v-model="value.body"
-      />
-    </p>
+    <slot name="before-content" />
 
-    <v-divider v-if="value.created && value.edited" />
-    <v-card-actions v-if="value.created && value.edited">
-      <v-breadcrumbs :items="breadcrumbs" />
-      <v-spacer />
-      <span class="overline">
-        Created {{ created }} - Last edited {{ lastEdited }}
-      </span>
-      <v-btn
-        v-if="$auth.loggedIn && $auth.user.owner"
-        text
-        @click="activateQuickEdit"
-      >
-        Quick edit
-      </v-btn>
-    </v-card-actions>
+    <slot />
 
-    <v-dialog
-      v-if="$auth.loggedIn && $auth.user.owner"
-      v-model="quickEdit"
-      persistent
-      width="1200"
-    >
-      <v-card>
-        <v-card-title class="title">
-          Edit {{ editPage.name }}
-        </v-card-title>
+    <slot name="after-content" />
 
-        <v-divider />
+    <slot name="page-footer">
+      <v-card-actions>
+        <slot name="page-information" />
+        <v-spacer />
+        <slot name="page-actions" />
+      </v-card-actions>
+    </slot>
 
-        <wtf-page-editor
-          v-model="editPage"
-          quick
-          @saved="reload"
-          @canceled="quickEdit = false"
-        />
-      </v-card>
-    </v-dialog>
+    <slot name="append" />
   </div>
 </template>
 
 <script>
-import moment from 'moment'
-
 export default {
   props: {
-    value: {
-      type: Object,
-      default () {
-        return {
-          _id: '',
-          name: '',
-          slug: '',
-          parent: '',
-          body: '',
-          created: new Date(),
-          edited: new Date()
-        }
-      }
-    },
     breadcrumbs: {
       type: Array,
       default: () => []
-    }
-  },
-  data () {
-    return {
-      quickEdit: false,
-      editPage: {}
-    }
-  },
-  computed: {
-    created () {
-      return moment(this.value.created).fromNow()
-    },
-    lastEdited () {
-      return moment(this.value.edited).fromNow()
-    }
-  },
-  methods: {
-    activateQuickEdit () {
-      if (this.$auth.loggedIn && this.$auth.user.owner) {
-        this.quickEdit = true
-        this.editPage = Object.assign(this.value)
-      }
-    },
-    reload (newPage) {
-      this.editPage = newPage
-      this.quickEdit = false
-      this.$emit('input', newPage)
     }
   }
 }

--- a/components/wtf-page-viewer.vue
+++ b/components/wtf-page-viewer.vue
@@ -93,8 +93,8 @@ export default {
     },
     reload (newPage) {
       this.editPage = newPage
-      this.value = newPage
       this.quickEdit = false
+      this.$emit('input', newPage)
     }
   }
 }

--- a/components/wtf-post-card.vue
+++ b/components/wtf-post-card.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-card v-if="post" :to="`/blog/${post.category.slug}/${post.slug}`">
+    <v-list-item three-line dense>
+      <v-list-item-content>
+        <v-list-item-title class="overline">
+          {{ post.category.slug }}
+        </v-list-item-title>
+        <v-list-item-subtitle class="title">
+          {{ post.name }}
+        </v-list-item-subtitle>
+        <v-list-item-subtitle>
+          Posted {{ created }} by {{ author }}.
+        </v-list-item-subtitle>
+      </v-list-item-content>
+    </v-list-item>
+
+    <v-card-text v-if="post.excerpt">
+      {{ post.excerpt }}
+    </v-card-text>
+  </v-card>
+</template>
+
+<script>
+import moment from 'moment'
+
+export default {
+  props: {
+    post: {
+      type: Object,
+      default () {
+        return {
+          _id: '',
+          name: '',
+          slug: '',
+          category: {
+            name: '',
+            slug: ''
+          },
+          tags: [],
+          created: new Date(),
+          author: {
+            _id: '',
+            owner: false,
+            admin: false,
+            editor: false,
+            moderator: false,
+            banned: false,
+            displayName: '',
+            username: ''
+          },
+          excerpt: '',
+          body: ''
+        }
+      }
+    }
+  },
+  computed: {
+    created () {
+      return moment(this.post.created).fromNow()
+    },
+    author () {
+      return this.post.author.displayName || this.post.author.username
+    }
+  }
+}
+</script>

--- a/components/wtf-quick-editor.vue
+++ b/components/wtf-quick-editor.vue
@@ -1,0 +1,63 @@
+<template>
+  <div>
+    <v-dialog
+      v-if="$auth.loggedIn && $auth.user.owner"
+      v-model="quickEdit"
+      persistent
+      width="1200"
+    >
+      <template v-slot:activator="{ on }">
+        <v-btn text v-on="on">
+          Quick Edit
+        </v-btn>
+      </template>
+      <v-card>
+        <v-card-title class="title">
+          Edit {{ value.name }}
+        </v-card-title>
+
+        <v-divider />
+
+        <wtf-page-editor
+          quick
+          :value="value"
+          @saved="reload"
+          @canceled="quickEdit = false"
+        />
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      quickEdit: false
+    }
+  },
+  props: {
+    value: {
+      type: Object,
+      default () {
+        return {
+          _id: null,
+          name: 'Page',
+          body: '',
+          slug: '',
+          created: new Date(),
+          edited: new Date(),
+          parent: null,
+          system: false
+        }
+      }
+    }
+  },
+  methods: {
+    reload (page) {
+      this.quickEdit = false
+      this.$emit('input', page)
+    }
+  }
+}
+</script>

--- a/components/wtf-quick-editor.vue
+++ b/components/wtf-quick-editor.vue
@@ -31,11 +31,6 @@
 
 <script>
 export default {
-  data () {
-    return {
-      quickEdit: false
-    }
-  },
   props: {
     value: {
       type: Object,
@@ -51,6 +46,11 @@ export default {
           system: false
         }
       }
+    }
+  },
+  data () {
+    return {
+      quickEdit: false
     }
   },
   methods: {

--- a/components/wtf-recursive-pages-list.vue
+++ b/components/wtf-recursive-pages-list.vue
@@ -11,7 +11,9 @@
             <v-tooltip bottom>
               <template v-slot:activator="{ on }">
                 <v-chip v-if="page.system" small v-on="on">
-                  <v-icon small>mdi-lock</v-icon>
+                  <v-icon small>
+                    mdi-lock
+                  </v-icon>
                   System page
                 </v-chip>
               </template>
@@ -54,7 +56,6 @@
         <wtf-recursive-pages-list v-model="value" :parent="page._id" @delete="deletePage" />
       </v-list>
     </div>
-
   </div>
 </template>
 

--- a/components/wtf-recursive-pages-list.vue
+++ b/components/wtf-recursive-pages-list.vue
@@ -8,6 +8,17 @@
         <v-list-item-content>
           <v-list-item-title>
             {{ page.name }}
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on }">
+                <v-chip v-if="page.system" small v-on="on">
+                  <v-icon small>mdi-lock</v-icon>
+                  System page
+                </v-chip>
+              </template>
+              <span>
+                System pages cannot be moved, renamed, or deleted.
+              </span>
+            </v-tooltip>
           </v-list-item-title>
           <v-list-item-subtitle>
             Created
@@ -27,12 +38,12 @@
         </v-btn>
         <v-btn
           icon
-          :to="`/admin/pages/${page._id}`"
+          :to="editUrlOf(page)"
         >
           <v-icon>mdi-lead-pencil</v-icon>
         </v-btn>
         <v-btn
-          v-if="page.slug !== '<index>'"
+          v-if="!page.system"
           icon
           @click="deletePage(page)"
         >
@@ -75,6 +86,9 @@ export default {
     },
     edited (page) {
       return moment(page.edited).fromNow()
+    },
+    editUrlOf (page) {
+      return `/admin/pages/${page._id}`
     },
     parentOf (page) {
       if (page.parent) {

--- a/components/wtf-user-menu.vue
+++ b/components/wtf-user-menu.vue
@@ -2,20 +2,20 @@
   <div>
     <v-menu v-if="$auth.loggedIn" offset-y>
       <template v-slot:activator="{ on }">
-        <v-list nav>
-          <v-list-item nav color="transparent" v-on="on">
-            <v-list-item-avatar color="primary">
-              <v-icon>mdi-account</v-icon>
-            </v-list-item-avatar>
-            <v-list-item-content>
-              <v-list-item-title>{{ $auth.user.displayName || $auth.user.username }}</v-list-item-title>
-              <v-list-item-subtitle>Logged in</v-list-item-subtitle>
-            </v-list-item-content>
-            <v-list-item-icon>
-              <v-icon>mdi-chevron-down</v-icon>
-            </v-list-item-icon>
-          </v-list-item>
-        </v-list>
+        <v-list-item nav class="transparent d-flex justify-start align-center flex-row" v-on="on">
+          <v-avatar color="primary" size="32" />
+          <v-flex class="d-flex flex-column ml-3 mr-3">
+            <span class="subtitle-2">
+              {{ $auth.user.displayName || $auth.user.username }}
+            </span>
+            <span class="caption">
+              {{ rank }}
+            </span>
+          </v-flex>
+          <v-icon>
+            mdi-chevron-down
+          </v-icon>
+        </v-list-item>
       </template>
 
       <v-list subheader>
@@ -47,3 +47,24 @@
     </div>
   </div>
 </template>
+
+<script>
+export default {
+  computed: {
+    rank () {
+      const { owner, admin, moderator, editor } = this.$auth.user
+      if (owner) {
+        return 'Owner'
+      } else if (admin) {
+        return 'Administrator'
+      } else if (editor) {
+        return 'Editor'
+      } else if (moderator) {
+        return 'Moderator'
+      } else {
+        return 'Logged in'
+      }
+    }
+  }
+}
+</script>

--- a/components/wtf-youtube.vue
+++ b/components/wtf-youtube.vue
@@ -1,0 +1,31 @@
+<template>
+  <v-responsive :aspect-ratio="16/9">
+    <iframe
+      frameborder="0"
+      :src="src"
+    />
+  </v-responsive>
+</template>
+
+<script>
+export default {
+  props: {
+    id: {
+      type: String,
+      default: () => ''
+    }
+  },
+  computed: {
+    src () {
+      return `https://youtube.com/embed/${this.id}`
+    }
+  }
+}
+</script>
+
+<style>
+iframe {
+  width: 100% !important;
+  height: 100% !important;
+}
+</style>

--- a/layouts/admin.vue
+++ b/layouts/admin.vue
@@ -26,9 +26,7 @@
 
     <v-content>
       <v-container fluid>
-        <v-card color="transparent">
-          <nuxt />
-        </v-card>
+        <nuxt />
       </v-container>
     </v-content>
   </v-app>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -169,7 +169,13 @@
                 wtf-pwa | Developed by Michael VanOverbeek.
               </p>
               <v-flex class="d-flex flex-row align-center ml-auto mr-auto">
-                <v-btn small text v-if="settings.showDeveloperCredit && settings.developerGitHubLinkInCredit" href="https://github.com/alkalinethunder/wtf-pwa" class="caption">
+                <v-btn
+                  v-if="settings.showDeveloperCredit && settings.developerGitHubLinkInCredit"
+                  small
+                  text
+                  href="https://github.com/alkalinethunder/wtf-pwa"
+                  class="caption"
+                >
                   Source code
                 </v-btn>
                 <v-btn

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,12 +1,12 @@
 <template>
-  <v-app color="primary">
+  <v-app>
     <v-navigation-drawer
       v-model="drawer"
       temporary
-      :color="themeBackground"
       width="100%"
       dark
       app
+      :color="themeBackground"
       class="d-sm-none"
     >
       <v-list-item>
@@ -31,10 +31,10 @@
 
     <v-app-bar
       fixed
-      :color="themeBackground"
       dark
       flat
       class="d-xs-block d-sm-none"
+      :color="themeBackground"
     >
       <v-app-bar-nav-icon @click="drawer = !drawer" />
       <v-flex class="d-flex flex-column ml-3">
@@ -49,8 +49,8 @@
       class="d-none d-md-block"
       app
       inverted-scroll
-      :color="themeBackground"
       dark
+      :color="themeBackground"
     >
       <v-flex class="d-flex flex-column ml-3">
         <v-toolbar-title>{{ settings.name }}</v-toolbar-title>
@@ -65,7 +65,6 @@
       <wtf-user-menu />
     </v-app-bar>
     <v-content :class="themeBackground">
-      <v-spacer class="mt-12 d-xs-block" />
       <v-container>
         <v-app-bar
           flat

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -37,7 +37,12 @@
       class="d-xs-block d-sm-none"
     >
       <v-app-bar-nav-icon @click="drawer = !drawer" />
-      <v-toolbar-title>{{ settings.name }}</v-toolbar-title>
+      <v-flex class="d-flex flex-column ml-3">
+        <v-toolbar-title>{{ settings.name }}</v-toolbar-title>
+        <span class="caption">
+          {{ settings.description }}
+        </span>
+      </v-flex>
     </v-app-bar>
 
     <v-app-bar
@@ -47,10 +52,16 @@
       :color="themeBackground"
       dark
     >
-      <v-toolbar-title>{{ settings.name }}</v-toolbar-title>
+      <v-flex class="d-flex flex-column ml-3">
+        <v-toolbar-title>{{ settings.name }}</v-toolbar-title>
+        <span class="caption">
+          {{ settings.description }}
+        </span>
+      </v-flex>
       <wtf-navigation />
       <v-spacer />
       <wtf-socials />
+      <wtf-dark-mode-toggle />
       <wtf-user-menu />
     </v-app-bar>
     <v-content :class="themeBackground">
@@ -64,8 +75,15 @@
           dark
           class="d-none d-sm-block"
         >
-          <v-toolbar-title class="display-3">
-            {{ settings.name }}
+          <v-toolbar-title>
+            <v-flex class="d-flex flex-column mb-6">
+              <h1 class="display-3">
+                {{ settings.name }}
+              </h1>
+              <h2 class="headline">
+                {{ settings.description }}
+              </h2>
+            </v-flex>
           </v-toolbar-title>
 
           <v-spacer />
@@ -75,6 +93,7 @@
           <template slot="extension">
             <wtf-navigation />
             <v-spacer />
+            <wtf-dark-mode-toggle />
             <wtf-user-menu />
           </template>
         </v-app-bar>
@@ -143,32 +162,31 @@
                 </v-list>
               </v-col>
             </v-row>
+
+            <v-divider />
+
+            <v-flex class="d-flex flex-column justify-center text-center mt-3">
+              <p v-if="settings.showDeveloperCredit" class="caption">
+                wtf-pwa | Developed by Michael VanOverbeek.
+              </p>
+              <v-flex class="d-flex flex-row align-center ml-auto mr-auto">
+                <v-btn small text v-if="settings.showDeveloperCredit && settings.developerGitHubLinkInCredit" href="https://github.com/alkalinethunder/wtf-pwa" class="caption">
+                  Source code
+                </v-btn>
+                <v-btn
+                  v-if="$auth.loggedIn && ($auth.user.owner || $auth.user.admin)"
+                  small
+                  text
+                  to="/admin"
+                >
+                  Administration
+                </v-btn>
+              </v-flex>
+            </v-flex>
           </v-container>
         </v-sheet>
       </v-container>
     </v-content>
-
-    <v-footer app :dark="dark">
-      <span v-if="settings.showDeveloperCredit">
-        Developed by Michael VanOverbeek.
-        <a v-if="settings.developerGitHubLinkInCredit" href="https://github.com/alkalinethunder/wtf-pwa">
-          Source code
-        </a>
-      </span>
-      <v-spacer />
-      <v-btn
-        v-if="$auth.loggedIn && ($auth.user.owner || $auth.user.admin)"
-        small
-        text
-        to="/admin"
-      >
-        <v-icon>
-          mdi-cog
-        </v-icon>
-        Administrate
-      </v-btn>
-      <wtf-dark-mode-toggle small />
-    </v-footer>
   </v-app>
 </template>
 

--- a/layouts/empty.vue
+++ b/layouts/empty.vue
@@ -1,12 +1,12 @@
 <template>
   <v-app dark>
-    <v-app-content>
+    <v-content>
       <v-container fill-height fluid>
         <v-row align="center" justify="center">
           <nuxt />
         </v-row>
       </v-container>
-    </v-app-content>
+    </v-content>
   </v-app>
 </template>
 

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -1,10 +1,14 @@
 <template>
   <div>
-    <h1 class="display-3 text-center">What the fuck?</h1>
+    <h1 class="display-3 text-center">
+      What the fuck?
+    </h1>
 
     <div v-if="error.statusCode">
       <v-img v-if="settings.enableErrorCats" :src="`https://http.cat/${error.statusCode}`" />
-      <h1 v-else class="display-1 text-center">HTTP {{ error.statusCode }}</h1>
+      <h1 v-else class="display-1 text-center">
+        HTTP {{ error.statusCode }}
+      </h1>
     </div>
 
     <v-divider />
@@ -15,13 +19,17 @@
           <v-list-item-title class="overline">
             Error details
           </v-list-item-title>
-          <v-list-item-subtitle class="title">{{ error.message }}</v-list-item-subtitle>
+          <v-list-item-subtitle class="title">
+            {{ error.message }}
+          </v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>
 
       <v-list-item v-if="error.stack" two-line>
         <v-list-item-content>
-          <v-list-item-title class="overline">Stack trace</v-list-item-title>
+          <v-list-item-title class="overline">
+            Stack trace
+          </v-list-item-title>
           <v-list-item-subtitle>{{ error.stack }}</v-list-item-subtitle>
         </v-list-item-content>
       </v-list-item>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -102,6 +102,7 @@ module.exports = {
   */
   plugins: [
     { src: '~/plugins/menu.js', ssr: false },
+    { src: '~/plugins/prismEditor.js', ssr: false },
     { src: '~/plugins/localStorage.js', ssr: false },
     { src: '~/plugins/wtf-core.js', ssr: false },
     { src: '~/plugins/markdown.js', ssr: false }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "nuxt": "^2.0.0",
     "prismjs": "^1.20.0",
     "slugify": "^1.4.0",
+    "truncate": "^2.1.0",
     "vue-code-highlight": "^0.7.4",
     "vue-markdown-renderer": "^0.2.1",
     "vuetify-markdown-editor": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "mongoose": "^5.9.9",
     "npm": "^6.14.4",
     "nuxt": "^2.0.0",
+    "prismjs": "^1.20.0",
     "slugify": "^1.4.0",
     "vue-code-highlight": "^0.7.4",
     "vue-markdown-renderer": "^0.2.1",

--- a/pages/_.vue
+++ b/pages/_.vue
@@ -1,6 +1,20 @@
 <template>
   <div>
-    <wtf-page-viewer v-model="page" :breadcrumbs="breadcrumbs" />
+    <wtf-page-viewer :breadcrumbs="breadcrumbs">
+      <template slot="title">
+        {{ page.name }}
+      </template>
+
+      <wtf-renderer v-model="page.body" />
+
+      <template slot="page-information">
+        Created {{ created }}, last edited {{ lastEdited }}.
+      </template>
+
+      <template slot="page-actions">
+        <wtf-quick-editor v-model="page" />
+      </template>
+    </wtf-page-viewer>
   </div>
 </template>
 

--- a/pages/admin/create-post.vue
+++ b/pages/admin/create-post.vue
@@ -21,6 +21,16 @@
           rows="1"
           auto-grow
         />
+        <v-select
+          v-model="post.category"
+          item-text="name"
+          item-value="_id"
+          dense
+          solo
+          flat
+          label="Category"
+          :items="categories"
+        />
 
         <v-textarea
           v-model="post.excerpt"
@@ -57,6 +67,7 @@ export default {
       valid: false,
       error: false,
       errorMessage: '',
+      categories: [],
       post: {
         name: '',
         body: '',
@@ -74,6 +85,15 @@ export default {
       }
       return splitTags
     }
+  },
+  mounted () {
+    this.$axios.get('/api/category')
+      .then((res) => {
+        this.categories = res.data
+        this.post.category = this.categories.find(x => x.slug === 'uncategorized')._id
+      }).catch((err) => {
+        this.$nuxt.error(err)
+      })
   },
   methods: {
     submitPost () {

--- a/pages/admin/create-post.vue
+++ b/pages/admin/create-post.vue
@@ -9,54 +9,44 @@
     <v-card-subtitle class="d-block d-md-none">
       Good blog posts have a post title, excerpt, featured image, and nicely formatted body.  Use the form below to create your post.  Scroll further down to see a preview of what your users will see.
     </v-card-subtitle>
-    <v-row>
-      <v-col
-        cols="12"
-        md="6"
-      >
-        <v-form v-model="valid" @submit="submitPost">
-          <v-card-text>
-            <v-text-field v-model="post.name" dense label="Post title" />
-            <v-text-field v-model="post.excerpt" dense label="Excerpt" />
-          </v-card-text>
+    <v-card>
+      <v-card-text>
+        <v-textarea
+          v-model="post.name"
+          class="display-1 transparent"
+          dense
+          solo
+          flat
+          label="Post name"
+          rows="1"
+          auto-grow
+        />
 
-          <Editor v-model="post.body" mode="editor" />
+        <v-textarea
+          v-model="post.excerpt"
+          rows="1"
+          auto-grow
+          dense
+          solo
+          flat
+          label="Post excerpt"
+          class="body-2"
+        />
 
-          <v-btn
-            fab
-            fixed
-            bottom
-            right
-            type="submit"
-            color="primary"
-          >
-            <v-icon>mdi-send</v-icon>
-          </v-btn>
-        </v-form>
-      </v-col>
-      <v-col
-        cols="12"
-        md="6"
-      >
-        <v-card
-          raised
-          outline
-        >
-          <v-card-subtitle>PREVIEW</v-card-subtitle>
-          <v-card-title class="display-1">
-            {{ post.name || 'Untitled post' }}
-          </v-card-title>
+        <wtf-markdown-editor v-model="post.body" />
+      </v-card-text>
+    </v-card>
 
-          <v-card-text v-if="post.excerpt">
-            {{ post.excerpt }}
-          </v-card-text>
-
-          <v-card-text>
-            <wtf-renderer v-model="post.body" />
-          </v-card-text>
-        </v-card>
-      </v-col>
-    </v-row>
+    <v-btn
+      fab
+      fixed
+      bottom
+      right
+      color="primary"
+      @click="submitPost"
+    >
+      <v-icon>mdi-send</v-icon>
+    </v-btn>
   </div>
 </template>
 
@@ -86,9 +76,7 @@ export default {
     }
   },
   methods: {
-    submitPost (evt) {
-      evt.preventDefault()
-
+    submitPost () {
       const publish = {
         name: this.post.name,
         excerpt: this.post.excerpt,

--- a/pages/admin/menus.vue
+++ b/pages/admin/menus.vue
@@ -18,12 +18,12 @@
     <v-divider />
 
     <v-row>
-      <v-col v-for="slot of theme.menus" cols="12" md="6" :key="slot.slot">
+      <v-col v-for="slot of theme.menus" :key="slot.slot" cols="12" md="6">
         <v-card raised>
           <v-list-item three-line>
             <v-list-item-content>
               <v-list-item-title class="overline">
-                {{ slot.slot }} ({{ theme.name}} Menu Slot)
+                {{ slot.slot }} ({{ theme.name }} Menu Slot)
               </v-list-item-title>
               <v-list-item-subtitle class="title">
                 {{ slot.name }}
@@ -60,8 +60,8 @@
             </v-list-item>
           </v-list>
           <v-card-text v-else>
-              This slot has no menu items in it.  The slot will not display on the page until at least one
-              item is added.
+            This slot has no menu items in it.  The slot will not display on the page until at least one
+            item is added.
           </v-card-text>
         </v-card>
       </v-col>

--- a/pages/admin/pages/_id.vue
+++ b/pages/admin/pages/_id.vue
@@ -4,7 +4,11 @@
       Edit page
     </v-card-title>
 
-    <wtf-page-editor v-model="page" fab @saved="goBack" />
+    <v-card v-if="page">
+      <v-card-text>
+        <wtf-page-editor v-model="page" fab @saved="goBack" />
+      </v-card-text>
+    </v-card>
   </div>
 </template>
 

--- a/pages/admin/pages/_id.vue
+++ b/pages/admin/pages/_id.vue
@@ -5,9 +5,7 @@
     </v-card-title>
 
     <v-card v-if="page">
-      <v-card-text>
-        <wtf-page-editor v-model="page" fab @saved="goBack" />
-      </v-card-text>
+      <wtf-page-editor v-model="page" fab @saved="goBack" />
     </v-card>
   </div>
 </template>

--- a/pages/admin/pages/create.vue
+++ b/pages/admin/pages/create.vue
@@ -4,7 +4,9 @@
       Create page
     </v-card-title>
 
-    <wtf-page-editor v-model="page" fab creator @saved="created" />
+    <v-card>
+      <wtf-page-editor v-model="page" fab creator @saved="created" />
+    </v-card>
   </div>
 </template>
 

--- a/pages/admin/posts/_id.vue
+++ b/pages/admin/posts/_id.vue
@@ -1,0 +1,77 @@
+<template>
+  <div>
+    <v-card>
+      <v-card-text>
+        <v-textarea
+          v-model="post.name"
+          dense
+          solo
+          flat
+          rows="1"
+          auto-grow
+          class="display-1"
+          label="Post title"
+        />
+
+        <v-textarea
+          v-model="post.excerpt"
+          dense
+          flat
+          solo
+          rows="1"
+          auto-grow
+          class="body-1"
+          label="Post excerpt"
+        />
+
+        <wtf-markdown-editor v-model="post.body" label="Start writing your post here. GitHub-flavoured Markdown is supported." />
+      </v-card-text>
+    </v-card>
+
+    <v-btn
+      color="primary"
+      fab
+      fixed
+      bottom
+      right
+      @click="savePost"
+    >
+      <v-icon>mdi-send</v-icon>
+    </v-btn>
+  </div>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      post: {
+        _id: '',
+        slug: '',
+        body: '',
+        name: '',
+        excerpt: '',
+        created: new Date()
+      }
+    }
+  },
+  mounted () {
+    this.$axios.get(`/api/posts/${this.$route.params.id}`)
+      .then((res) => {
+        this.post = res.data
+      }).catch((err) => {
+        this.$nuxt.error(err)
+      })
+  },
+  methods: {
+    savePost () {
+      this.$axios.post(`/api/posts/${this.post.slug}`, this.post)
+        .then((res) => {
+          this.$router.replace('/admin/posts')
+        }).catch((err) => {
+          this.$nuxt.error(err)
+        })
+    }
+  }
+}
+</script>

--- a/pages/admin/posts/index.vue
+++ b/pages/admin/posts/index.vue
@@ -47,7 +47,7 @@
             </v-list-item>
 
             <v-list-item @click="showDeleteDialog(post)">
-              <v-list-item-content>\
+              <v-list-item-content>
                 <v-list-item-title>Delete</v-list-item-title>
               </v-list-item-content>
             </v-list-item>
@@ -57,7 +57,9 @@
     </v-list>
 
     <v-card-text v-if="!posts.length" class="text-center">
-      <h1 class="headline">No posts here...</h1>
+      <h1 class="headline">
+        No posts here...
+      </h1>
       <p>There are no posts to display on this page. Your blog is empty.</p>
       <v-btn color="primary" to="/admin/create-post">
         Create your first post!

--- a/pages/admin/posts/index.vue
+++ b/pages/admin/posts/index.vue
@@ -152,7 +152,7 @@ export default {
       this.deleteOpen = true
     },
     postEdit (post) {
-      return `/admin/posts/edit/${post.slug}`
+      return `/admin/posts/${post.slug}`
     },
     moreInfo (post) {
       this.more = post

--- a/pages/admin/posts/index.vue
+++ b/pages/admin/posts/index.vue
@@ -19,7 +19,12 @@
         </v-list-item-icon>
 
         <v-list-item-content>
-          <v-list-item-title>{{ post.name }}</v-list-item-title>
+          <v-list-item-title>
+            {{ post.name }}
+            <v-chip small>
+              {{ post.category.name }}
+            </v-chip>
+          </v-list-item-title>
           <v-list-item-subtitle>{{ createdAgo(post) }}</v-list-item-subtitle>
         </v-list-item-content>
 

--- a/pages/admin/posts/index.vue
+++ b/pages/admin/posts/index.vue
@@ -25,7 +25,7 @@
               {{ post.category.name }}
             </v-chip>
           </v-list-item-title>
-          <v-list-item-subtitle>{{ createdAgo(post) }}</v-list-item-subtitle>
+          <v-list-item-subtitle>{{ createdAgo(post) }} by {{ postAuthor(post) }}</v-list-item-subtitle>
         </v-list-item-content>
 
         <v-btn icon :to="postEdit(post)">
@@ -158,6 +158,9 @@ export default {
     },
     postEdit (post) {
       return `/admin/posts/${post.slug}`
+    },
+    postAuthor (post) {
+      return post.author.displayName || post.author.username
     },
     moreInfo (post) {
       this.more = post

--- a/pages/blog/_category/_slug.vue
+++ b/pages/blog/_category/_slug.vue
@@ -21,7 +21,7 @@
           Comments
         </h4>
 
-        <wtf-comments v-model="comments" :post-id="post.slug" />
+        <wtf-comments v-model="comments" :post-id="post._id" />
       </template>
 
       <template slot="sidebar">
@@ -91,7 +91,7 @@ export default {
       },
       recent: [],
       commentBody: '',
-      comments: []
+      comments: {}
     }
   },
   computed: {
@@ -120,13 +120,9 @@ export default {
               this.recent = sortedByDate
             }
 
-            this.$axios.get(`/api/posts/${this.post.slug}/comments`)
+            this.$axios.get(`/api/comments/${this.post._id}`)
               .then((res) => {
-                this.comments = res.data.sort((a, b) => {
-                  const aDate = Date.parse(a.posted)
-                  const bDate = Date.parse(b.posted)
-                  return bDate - aDate
-                })
+                this.comments = res.data
               })
           })
       })

--- a/pages/blog/_category/_slug.vue
+++ b/pages/blog/_category/_slug.vue
@@ -1,45 +1,34 @@
 <template>
-  <div v-if="post">
-    <h1 class="headline">
-      {{ post.name }}
-    </h1>
-    <h2 class="subtitle-2 text--secondary">
-      Posted {{ getCreatedAt(post) }}.
-    </h2>
+  <div>
+    <wtf-page-viewer>
+      <template slot="title">
+        {{ post.name }}
+      </template>
+      <template slot="before-content">
+        <h2 class="subtitle-2 text--secondary">
+          Posted {{ getCreatedAt(post) }} &bull;
+          <v-chip :to="`/blog/${post.category.slug}`" small>
+            {{ post.category.name }}
+          </v-chip>
+        </h2>
+      </template>
 
-    <v-row>
-      <v-col
-        cols="12"
-        md="8"
-      >
-        <v-img v-if="post.featuredUrl" :src="post.featuredUrl" />
+      <v-img v-if="post.featuredUrl" :src="post.featuredUrl" />
 
-        <p v-if="post.excerpt" class="body-2">
-          {{ post.excerpt }}
-        </p>
+      <p v-if="post.excerpt" class="body-2">
+        {{ post.excerpt }}
+      </p>
 
-        <div class="body-2">
-          <wtf-renderer v-model="post.body" />
-        </div>
+      <wtf-renderer v-model="post.body" />
 
-        <v-divider />
-
+      <template slot="after-content">
         <h4 class="subtitle-1">
           Comments
         </h4>
 
         <wtf-comments v-model="comments" :post-id="post.slug" />
-      </v-col>
-      <v-col
-        cols="12"
-        md="4"
-      >
-        <v-card-title>Related posts</v-card-title>
-        <v-card-text>
-          This part of the page is under construction and not yet implemented.
-        </v-card-text>
-      </v-col>
-    </v-row>
+      </template>
+    </wtf-page-viewer>
   </div>
 </template>
 
@@ -55,7 +44,10 @@ export default {
         created: new Date(),
         featuredUrl: '',
         tags: [],
-        category: null,
+        category: {
+          slug: 'uncategorized',
+          name: 'Uncategorized'
+        },
         views: 0
       },
       commentBody: '',

--- a/pages/blog/_category/_slug.vue
+++ b/pages/blog/_category/_slug.vue
@@ -6,7 +6,7 @@
       </template>
       <template slot="before-content">
         <h2 class="subtitle-2 text--secondary">
-          Posted {{ getCreatedAt(post) }} &bull;
+          Posted {{ created }} by {{ author }} &bull;
           <v-chip :to="`/blog/${post.category.slug}`" small>
             {{ post.category.name }}
           </v-chip>
@@ -44,6 +44,10 @@ export default {
         created: new Date(),
         featuredUrl: '',
         tags: [],
+        author: {
+          displayName: '',
+          username: ''
+        },
         category: {
           slug: 'uncategorized',
           name: 'Uncategorized'
@@ -52,6 +56,14 @@ export default {
       },
       commentBody: '',
       comments: []
+    }
+  },
+  computed: {
+    created () {
+      return moment(this.post.created).fromNow()
+    },
+    author () {
+      return this.post.author.displayName || this.post.author.username
     }
   },
   mounted () {

--- a/pages/blog/_category/index.vue
+++ b/pages/blog/_category/index.vue
@@ -1,0 +1,94 @@
+<template>
+  <div>
+    <wtf-page-viewer>
+      <template slot="title">
+        <h1 class="display-1">
+          All posts in "{{ category.name }}"
+        </h1>
+      </template>
+
+      <template slot="before-content">
+        <p class="body-1">
+          This is a list of all blog posts in the category "{{ category.name }}".
+        </p>
+      </template>
+
+      <v-card v-for="post in posts" :key="post._id" :to="`/blog/${post.category.slug}/${post.slug}`">
+        <v-list-item three-line dense>
+          <v-list-item-content>
+            <v-list-item-title class="overline">
+              {{ post.category.slug }}
+            </v-list-item-title>
+            <v-list-item-subtitle class="title">
+              {{ post.name }}
+            </v-list-item-subtitle>
+            <v-list-item-subtitle>
+              Created {{ created(post) }}.
+            </v-list-item-subtitle>
+          </v-list-item-content>
+        </v-list-item>
+
+        <v-card-text v-if="post.excerpt">
+          {{ post.excerpt }}
+        </v-card-text>
+      </v-card>
+    </wtf-page-viewer>
+  </div>
+</template>
+
+<script>
+import moment from 'moment'
+
+export default {
+  data () {
+    return {
+      posts: [],
+      category: {},
+      page: {
+        _id: null,
+        name: 'Blog',
+        body: '',
+        slug: 'blog',
+        parent: null,
+        created: null,
+        edited: null
+      },
+      breadcrumbs: [
+        {
+          text: '/',
+          to: '/',
+          exact: true
+        },
+        {
+          text: 'Blog',
+          to: '/blog',
+          exact: true
+        }
+      ]
+    }
+  },
+  mounted () {
+    this.$axios.get(`/api/category/${this.$route.params.category}`)
+      .then((res) => {
+        this.category = res.data.category
+        this.posts = res.data.posts
+
+        this.page.name = `All posts in "${this.category.name}"`
+        this.page.slug = this.category.slug
+
+        this.breadcrumbs.push({
+          text: this.category.name,
+          slug: `/blog/${this.category.slug}`,
+          exact: true
+        })
+      }).catch((err) => {
+        this.$nuxt.error(err)
+      })
+  },
+  methods: {
+    created (post) {
+      return moment(post.created).fromNow()
+    }
+  }
+}
+</script>

--- a/pages/blog/_category/index.vue
+++ b/pages/blog/_category/index.vue
@@ -13,25 +13,7 @@
         </p>
       </template>
 
-      <v-card v-for="post in posts" :key="post._id" :to="`/blog/${post.category.slug}/${post.slug}`">
-        <v-list-item three-line dense>
-          <v-list-item-content>
-            <v-list-item-title class="overline">
-              {{ post.category.slug }}
-            </v-list-item-title>
-            <v-list-item-subtitle class="title">
-              {{ post.name }}
-            </v-list-item-subtitle>
-            <v-list-item-subtitle>
-              Created {{ created(post) }}.
-            </v-list-item-subtitle>
-          </v-list-item-content>
-        </v-list-item>
-
-        <v-card-text v-if="post.excerpt">
-          {{ post.excerpt }}
-        </v-card-text>
-      </v-card>
+      <wtf-post-card v-for="post of posts" :post="post" :key="post._id" />
     </wtf-page-viewer>
   </div>
 </template>

--- a/pages/blog/_category/index.vue
+++ b/pages/blog/_category/index.vue
@@ -13,7 +13,7 @@
         </p>
       </template>
 
-      <wtf-post-card v-for="post of posts" :post="post" :key="post._id" />
+      <wtf-post-card v-for="post of posts" :key="post._id" :post="post" />
     </wtf-page-viewer>
   </div>
 </template>

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -1,32 +1,48 @@
 <template>
   <div>
-    <wtf-page-viewer v-model="page" :breadcrumbs="breadcrumbs" />
+    <wtf-page-viewer :breadcrumbs="breadcrumbs">
+      <template slot="title">
+        {{ page.name }}
+      </template>
 
-    <div v-if="posts.length">
-      <div v-for="post of posts" :key="post.id">
-        <v-card :to="url(post)">
-          <v-img v-if="post.featuredUrl" :src="post.featuredUrl" />
+      <template slot="before-content">
+        <wtf-renderer v-model="page.body" />
+      </template>
 
-          <v-card-title>
-            {{ post.name }}
-          </v-card-title>
-          <v-card-subtitle>
-            Created {{ getCreatedDate(post) }}
-          </v-card-subtitle>
+      <div v-if="posts.length">
+        <v-card v-for="post in posts" :key="post._id" :to="`/blog/${post.category.slug}/${post.slug}`">
+          <v-list-item three-line dense>
+            <v-list-item-content>
+              <v-list-item-title class="overline">
+                {{ post.category.slug }}
+              </v-list-item-title>
+              <v-list-item-subtitle class="title">
+                {{ post.name }}
+              </v-list-item-subtitle>
+              <v-list-item-subtitle>
+                Created {{ getCreatedDate(post) }}.
+              </v-list-item-subtitle>
+            </v-list-item-content>
+          </v-list-item>
 
-          <v-card-text>
+          <v-card-text v-if="post.excerpt">
             {{ post.excerpt }}
           </v-card-text>
         </v-card>
-      </div>
-    </div>
-    <div v-else>
-      <v-card outlined class="text-center">
-        <v-card-subtitle>This is awkward.</v-card-subtitle>
 
-        <v-card-text>There are currently no blog posts to display.</v-card-text>
-      </v-card>
-    </div>
+      </div>
+      <div v-else>
+        <v-card outlined class="text-center">
+          <v-card-subtitle>This is awkward.</v-card-subtitle>
+
+          <v-card-text>There are currently no blog posts to display.</v-card-text>
+        </v-card>
+      </div>
+
+      <template slot="page-actions">
+        <wtf-quick-editor v-model="page" />
+      </template>
+    </wtf-page-viewer>
   </div>
 </template>
 
@@ -65,6 +81,10 @@ export default {
     this.$axios.get('/api/posts')
       .then((res) => {
         this.posts = res.data
+        this.$axios.get('/api/page/blog')
+          .then((res) => {
+            this.page = res.data.page
+          })
       })
       .catch((err) => {
         if (err) {
@@ -74,7 +94,7 @@ export default {
   },
   methods: {
     url (post) {
-      return `/blog/${post.slug}`
+      return `/blog/${post.category.slug}/${post.slug}`
     },
     getCreatedDate (post) {
       return moment(post.created).fromNow()

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -10,7 +10,7 @@
       </template>
 
       <div v-if="posts.length">
-        <wtf-post-card v-for="post of posts" :post="post" :key="post._id" />
+        <wtf-post-card v-for="post of posts" :key="post._id" :post="post" />
       </div>
       <div v-else>
         <v-card outlined class="text-center">

--- a/pages/blog/index.vue
+++ b/pages/blog/index.vue
@@ -10,26 +10,7 @@
       </template>
 
       <div v-if="posts.length">
-        <v-card v-for="post in posts" :key="post._id" :to="`/blog/${post.category.slug}/${post.slug}`">
-          <v-list-item three-line dense>
-            <v-list-item-content>
-              <v-list-item-title class="overline">
-                {{ post.category.slug }}
-              </v-list-item-title>
-              <v-list-item-subtitle class="title">
-                {{ post.name }}
-              </v-list-item-subtitle>
-              <v-list-item-subtitle>
-                Created {{ getCreatedDate(post) }}.
-              </v-list-item-subtitle>
-            </v-list-item-content>
-          </v-list-item>
-
-          <v-card-text v-if="post.excerpt">
-            {{ post.excerpt }}
-          </v-card-text>
-        </v-card>
-
+        <wtf-post-card v-for="post of posts" :post="post" :key="post._id" />
       </div>
       <div v-else>
         <v-card outlined class="text-center">

--- a/pages/u/_username.vue
+++ b/pages/u/_username.vue
@@ -105,7 +105,6 @@
         </v-card>
       </v-container>
     </v-dialog>
-
   </div>
 </template>
 

--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -42,7 +42,7 @@ Vue.use(mdRenderer, {
       if (token.href.startsWith('>')) {
         return createElement(config.elements.routerLink, {
           props: {
-            to: token.href.splice(0, 1)
+            to: token.href.substring(1)
           }
         }, processTokens(token.tokens, createElement, config))
       } else {

--- a/plugins/markdown.js
+++ b/plugins/markdown.js
@@ -1,8 +1,10 @@
 import Vue from 'vue'
 import mdRenderer from 'vue-markdown-renderer'
 import { component as VueCodeHighlight } from 'vue-code-highlight'
-import '~/node_modules/vue-code-highlight/themes/prism-twilight.css'
 
+import 'prismjs/themes/prism-twilight.css'
+
+Vue.component('wtf-markdown-editor', async () => (await import('~/components/wtf-markdown-editor.vue')))
 Vue.component('Editor', async () => (await import('vuetify-markdown-editor')).Editor)
 Vue.component('wtf-renderer', async () => (await import('~/components/wtf-renderer.vue')))
 

--- a/plugins/wtf-core.js
+++ b/plugins/wtf-core.js
@@ -7,6 +7,8 @@ Vue.component('wtf-drawer-user-menu', () => (import('~/components/wtf-drawer-use
 Vue.component('wtf-user-menu', () => (import('~/components/wtf-user-menu.vue')))
 Vue.component('wtf-socials', () => (import('~/components/wtf-socials.vue')))
 
+Vue.component('wtf-post-card', () => (import('~/components/wtf-post-card.vue')))
+
 Vue.component('wtf-comment', () => import('~/components/wtf-comment.vue'))
 Vue.component('wtf-comments', () => import('~/components/wtf-comments.vue'))
 

--- a/plugins/wtf-core.js
+++ b/plugins/wtf-core.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 
+Vue.component('wtf-quick-editor', () => (import('~/components/wtf-quick-editor.vue')))
 Vue.component('wtf-navigation', () => (import('~/components/wtf-navigation.vue')))
 Vue.component('wtf-drawer-navigation', () => (import('~/components/wtf-drawer-navigation.vue')))
 Vue.component('wtf-drawer-user-menu', () => (import('~/components/wtf-drawer-user-menu.vue')))

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config()
 const fs = require('fs')
 const path = require('path')
 const express = require('express')
@@ -11,8 +12,6 @@ const SiteSetting = require('./models/sitesetting')
 const themesPath = path.join(__dirname, '..', 'themes')
 const themePath = path.join(themesPath, 'material')
 const themeManifestPath = path.join(themePath, 'manifest.json')
-
-require('dotenv').config()
 
 // Import and Set Nuxt.js options
 config.dev = process.env.NODE_ENV !== 'production'

--- a/server/index.js
+++ b/server/index.js
@@ -85,6 +85,23 @@ async function start (siteSettings) {
   })
 }
 
+async function assignPostAuthors () {
+  const Post = require('./models/post')
+  const User = require('./models/user')
+
+  const owner = await User.findOne({ owner: true })
+
+  if (owner) {
+    const posts = await Post.find({})
+    for (const post of posts) {
+      if (!post.author) {
+        post.author = owner
+        await post.save()
+      }
+    }
+  }
+}
+
 async function createDefaultMenuItems () {
   const MenuItem = require('./models/menuitem')
   const Page = require('./models/page')
@@ -198,6 +215,7 @@ async function configureDatabase() {
 
   const uncategorized = await ensureSystemCategory('Uncategorized', 'uncategorized')
   await categorizeOldPosts(uncategorized)
+  await assignPostAuthors()
 
   const sitesettings = await ensureSiteSettingsExist()
   return sitesettings

--- a/server/index.js
+++ b/server/index.js
@@ -41,6 +41,7 @@ async function start (siteSettings) {
   const ThemeRouter = require('./routes/theme')
   const MenuRouter = require('./routes/menu')
   const CategoryRouter = require('./routes/category')
+  const CommentsRouter = require('./routes/comments')
 
   await nuxt.ready()
   // Build only in dev mode
@@ -63,6 +64,7 @@ async function start (siteSettings) {
   app.use('/api/theme', ThemeRouter)
   app.use('/api/menu', MenuRouter)
   app.use('/api/category', CategoryRouter)
+  app.use('/api/comments', CommentsRouter)
 
   app.use(function (req, res, next) {
     if (req.path.startsWith('/api')) {

--- a/server/index.js
+++ b/server/index.js
@@ -1,23 +1,20 @@
+const fs = require('fs')
+const path = require('path')
 const express = require('express')
 const consola = require('consola')
 const { Nuxt, Builder } = require('nuxt')
 const app = express()
-const mongoose = require('mongoose');
-const bodyParser = require('body-parser');
+const mongoose = require('mongoose')
+const bodyParser = require('body-parser')
+const config = require('../nuxt.config.js')
 const SiteSetting = require('./models/sitesetting')
-const fs = require('fs')
-const path = require('path')
-
 const themesPath = path.join(__dirname, '..', 'themes')
 const themePath = path.join(themesPath, 'material')
 const themeManifestPath = path.join(themePath, 'manifest.json')
 
 require('dotenv').config()
 
-
-
 // Import and Set Nuxt.js options
-const config = require('../nuxt.config.js')
 config.dev = process.env.NODE_ENV !== 'production'
 
 // read and parse the theme manifest.
@@ -54,10 +51,10 @@ async function start (siteSettings) {
   app.use(bodyParser())
 
   // give API routes so we have a backend.
-  app.use('/api/posts', postsRoute);
+  app.use('/api/posts', postsRoute)
   app.use('/api/setup', setupRouter)
-  app.use('/api/projects', projectsRoute);
-  app.use('/api/users', usersRoute);
+  app.use('/api/projects', projectsRoute)
+  app.use('/api/users', usersRoute)
   app.use('/api/auth', authRoute)
   app.use('/api/pages', PagesRouter)
   app.use('/api/page', PageRouter)
@@ -110,9 +107,9 @@ async function createDefaultMenuItems () {
 
   const systemPages = await Page.find({ system: true })
 
-  for (let page of pages) {
+  for (const page of systemPages) {
     const exists = await MenuItem.findOne({ name: page.Name, page: page._id, type: 'page' })
-    if  (!exists) {
+    if (!exists) {
       const menuItem = new MenuItem({
         name: page.name,
         slot: 'primary',
@@ -125,17 +122,17 @@ async function createDefaultMenuItems () {
 }
 
 async function ensureSiteSettingsExist () {
-  const sitesettings = SiteSetting.findOne({})
+  const sitesettings = await SiteSetting.findOne({})
   if (sitesettings) {
     return sitesettings
   } else {
-    const newSettings = new siteSetting({})
+    const newSettings = new SiteSetting({})
     await createDefaultMenuItems()
     return await newSettings.save()
   }
 }
 
-async function ensureSystemPage(name, slug, parent, body) {
+async function ensureSystemPage (name, slug, parent, body) {
   const Page = require('./models/page')
 
   const existingPage = await Page.findOne({
@@ -171,7 +168,7 @@ async function ensureSystemPage(name, slug, parent, body) {
   return existingPage
 }
 
-async function ensureSystemCategory(name, slug) {
+async function ensureSystemCategory (name, slug) {
   const Category = require('./models/category')
 
   const existingCategory = await Category.findOne({
@@ -209,11 +206,11 @@ async function categorizeOldPosts (category) {
   }
 }
 
-async function configureDatabase() {
+async function configureDatabase () {
   await mongoose.connect('mongodb://localhost/wtf', { useUnifiedTopology: true, useNewUrlParser: true })
 
-  const homepage = await ensureSystemPage('Home', '<index>', null, 'Edit this page in **Administration**.')
-  const blog = await ensureSystemPage('Blog', 'blog', null, 'Edit this page in **Administration**.')
+  await ensureSystemPage('Home', '<index>', null, 'Edit this page in **Administration**.')
+  await ensureSystemPage('Blog', 'blog', null, 'Edit this page in **Administration**.')
 
   const uncategorized = await ensureSystemCategory('Uncategorized', 'uncategorized')
   await categorizeOldPosts(uncategorized)

--- a/server/models/category.js
+++ b/server/models/category.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose')
+
+const { Schema } = mongoose
+
+const CategorySchema = new Schema({
+  name: { type: String, required: true },
+  slug: { type: String, required: true },
+  system: { type: Boolean, required: true, default: false }
+})
+
+module.exports = mongoose.model('category', CategorySchema)

--- a/server/models/post.js
+++ b/server/models/post.js
@@ -1,6 +1,6 @@
-const mongoose = require('mongoose');
+const mongoose = require('mongoose')
 
-const { Schema } = mongoose;
+const { Schema } = mongoose
 
 require('./category')
 require('./user')

--- a/server/models/post.js
+++ b/server/models/post.js
@@ -2,6 +2,8 @@ const mongoose = require('mongoose');
 
 const { Schema } = mongoose;
 
+require('./category')
+
 const PostSchema = new Schema({
   name: String,
   slug: String,
@@ -9,7 +11,7 @@ const PostSchema = new Schema({
   excerpt: String,
   body: String,
   views: { type: Number, default: 0 },
-  category: { type: String, default: null },
+  category: { type: Schema.Types.ObjectId, ref: 'category', default: null },
   tags: [{ type: String }],
   featuredUrl: { type: String, required: false, default: null }
 })

--- a/server/models/post.js
+++ b/server/models/post.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { Schema } = mongoose;
 
 require('./category')
+require('./user')
 
 const PostSchema = new Schema({
   name: String,
@@ -13,7 +14,8 @@ const PostSchema = new Schema({
   views: { type: Number, default: 0 },
   category: { type: Schema.Types.ObjectId, ref: 'category', default: null },
   tags: [{ type: String }],
-  featuredUrl: { type: String, required: false, default: null }
+  featuredUrl: { type: String, required: false, default: null },
+  author: { type: Schema.Types.ObjectId, required: false, ref: 'user' }
 })
 
 module.exports = mongoose.model('post', PostSchema)

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -63,7 +63,7 @@ router.get('/:name', async function (req, res) {
   try {
     const category = await Category.findOne({ slug: req.params.name })
     if (category) {
-      const posts = await Post.find({ category }).populate('category')
+      const posts = await Post.find({ category }).populate('category').populate('author')
       res.status(200).json({
         category,
         posts

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -1,0 +1,174 @@
+const express = require('express')
+const slugify = require('slugify')
+const Post = require('../models/post')
+const Category = require('../models/category')
+const auth = require('../middleware/auth')
+
+const router = express.Router()
+
+router.get('/', async function (req, res) {
+  try {
+    const categories = await Category.find({})
+    res.status(200).json(categories)
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
+    })
+  }
+})
+
+router.post('/', auth.owner, async function (req, res) {
+  try {
+    const { name } = req.body
+
+    if (name && name.trim()) {
+      const trimmed = name.trim()
+      const slug = slugify(trimmed)
+
+      const existing = await Category.findOne({
+        $or: [
+          { name: trimmed },
+          { slug }
+        ]
+      })
+
+      if (existing) {
+        res.status(400).json({
+          message: 'A category with that name already exists.'
+        })
+      } else {
+        const newCategory = new Category({
+          name: trimmed,
+          slug,
+          system: false
+        })
+
+        const saved = await newCategory.save()
+
+        res.status(200).json(saved)
+      }
+    } else {
+      res.status(400).json({
+        message: 'Category name is required and must not be whitespace.'
+      })
+    }
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
+    })
+  }
+})
+
+router.get('/:name', async function (req, res) {
+  try {
+    const category = await Category.findOne({ slug: req.params.name })
+    if (category) {
+      const posts = await Post.find({ category }).populate('category')
+      res.status(200).json({
+        category,
+        posts
+      })
+    } else {
+      res.status(404).json({
+        message: 'Category not found.'
+      })
+    }
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
+    })
+  }
+})
+
+router.post('/:name', auth.owner, async function (req, res) {
+  try {
+    const category = await Category.findOne({ slug: req.params.name })
+    if (category) {
+      if (category.system) {
+        res.status(403).json({
+          message: 'You cannot edit a system category.'
+        })
+      } else {
+        const name = req.body.name
+        if (name && name.trim()) {
+          const trimmed = name.trim()
+          const slug = slugify(trimmed)
+
+          if (category.name !== trimmed) {
+            const exists = await Category.findOne({
+              $or: [
+                { name: trimmed },
+                { slug }
+              ]
+            })
+
+            if (exists) {
+              return res.status(400).json({
+                message: 'A category with that name already exists.'
+              })
+            } else {
+              category.name = trimmed
+              category.slug = slug
+              const saved = await category.save()
+              return res.status(200).json(saved)
+            }
+          }
+        }
+        res.status(200).json({
+          message: 'No actions were taken.',
+          category
+        })
+      }
+    } else {
+      res.status(404).json({
+        message: 'Category not found.'
+      })
+    }
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
+    })
+  }
+})
+
+router.post('/:name/delete', auth.owner, async function (req, res) {
+  try {
+    const category = await Category.findOne({ slug: req.params.name })
+    if (category) {
+      // prevent deletion of a system category.
+      if (category.system) {
+        res.status(403).json({
+          message: 'You cannot delete a system category.'
+        })
+      } else {
+        // find the Uncategorized category and then find all posts in the to-be-deleted category.
+        const uncategorized = await Category.findOne({ slug: 'uncategorized' })
+        const posts = await Post.find({ category })
+
+        // move all posts to uncategorized.
+        for (const post of posts) {
+          post.category = uncategorized
+          await post.save()
+        }
+
+        // remove the category.
+        await Category.deleteOne(category)
+
+        // Done!
+        res.status(200).json({
+          message: 'Category deleted successfully.'
+        })
+      }
+    } else {
+      res.status(404).json({
+        message: 'Category not found.'
+      })
+    }
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
+    })
+  }
+})
+
+module.exports = router

--- a/server/routes/comments.js
+++ b/server/routes/comments.js
@@ -1,0 +1,117 @@
+const express = require('express')
+const auth = require('../middleware/auth')
+const Post = require('../models/post')
+const User = require('../models/user')
+const Comment = require('../models/comment')
+
+const router = express.Router()
+
+router.get('/', async function (req, res) {
+  try {
+    const comments = await Comment.find({}).populate('author')
+    res.status(200).json(comments)
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
+    })
+  }
+})
+
+router.post('/', auth.authenticate, async function (req, res) {
+  try {
+    const { type, commentFor, body } = req.body
+
+    switch (type) {
+      case 'post':
+        const postExists = await Post.findById(commentFor)
+        if (!postExists) {
+          return res.status(404).json({
+            message: 'Specified post does not exist.'
+          })
+        }
+        break;
+      case 'reply':
+        const existingComment = await Comment.findById(commentFor)
+        if (!existingComment) {
+          return res.status(404).json({
+            message: 'Specified comment not found.'
+          })
+        }
+        break;
+      default:
+        return res.status(400).json({
+          message: 'Invalid comment type.'
+        })
+    }
+
+    if (body && body.trim()) {
+      const newComment = new Comment({
+        belongsTo: commentFor,
+        body,
+        author: req.user,
+        commentType: type,
+        posted: new Date()
+      })
+
+      const saved = await newComment.save()
+
+      res.status(200).json(saved)
+    } else {
+      res.status(400).json({
+        message: 'Comment must have a non-whitespace body.'
+      })
+    }
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
+    })
+  }
+})
+
+router.get('/:post', async function (req, res) {
+  try {
+    const post = await Post.findById(req.params.post)
+
+    if (post) {
+      const comments = await Comment.find({
+        commentType: 'post',
+        belongsTo: post._id
+      }).populate('author')
+
+      const response = {
+        comments: comments.sort((a, b) => {
+          const aDate = new Date(a.posted)
+          const bDate = new Date(b.posted)
+
+          return bDate - aDate
+        }),
+        replies: {}
+      }
+
+      for (const comment of response.comments) {
+        const replies = await Comment.find({
+          belongsTo: comment._id,
+          commentType: 'reply'
+        }).populate('author')
+
+        response.replies[comment._id] = replies.sort((a, b) => {
+          const aDate = new Date(a.posted)
+          const bDate = new Date(b.posted)
+          return aDate - bDate
+        })
+      }
+
+      res.status(200).json(response)
+    } else {
+      res.status(404).json({
+        message: 'Post not found.'
+      })
+    }
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
+    })
+  }
+})
+
+module.exports = router

--- a/server/routes/comments.js
+++ b/server/routes/comments.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const auth = require('../middleware/auth')
 const Post = require('../models/post')
-const User = require('../models/user')
 const Comment = require('../models/comment')
 
 const router = express.Router()
@@ -21,27 +20,24 @@ router.post('/', auth.authenticate, async function (req, res) {
   try {
     const { type, commentFor, body } = req.body
 
-    switch (type) {
-      case 'post':
-        const postExists = await Post.findById(commentFor)
-        if (!postExists) {
-          return res.status(404).json({
-            message: 'Specified post does not exist.'
-          })
-        }
-        break;
-      case 'reply':
-        const existingComment = await Comment.findById(commentFor)
-        if (!existingComment) {
-          return res.status(404).json({
-            message: 'Specified comment not found.'
-          })
-        }
-        break;
-      default:
-        return res.status(400).json({
-          message: 'Invalid comment type.'
+    if (type === 'post') {
+      const postExists = await Post.findById(commentFor)
+      if (!postExists) {
+        return res.status(404).json({
+          message: 'Specified post does not exist.'
         })
+      }
+    } else if (type === 'reply') {
+      const existingComment = await Comment.findById(commentFor)
+      if (!existingComment) {
+        return res.status(404).json({
+          message: 'Specified comment not found.'
+        })
+      }
+    } else {
+      return res.status(400).json({
+        message: 'Invalid comment type.'
+      })
     }
 
     if (body && body.trim()) {

--- a/server/routes/pages.js
+++ b/server/routes/pages.js
@@ -248,49 +248,92 @@ router.get('/:id', function (req, res) {
   })
 })
 
-router.post('/:id', auth.owner, function (req, res) {
-  const { name, body } = req.body
-  const trimmedName = name && name.trim()
+router.post('/:id', auth.owner, async function (req, res) {
+  try {
+    const { name, parent, body } = req.body
+    const page = await Page.findById(req.params.id)
 
-  if (trimmedName) {
-    if(reservedNames.includes(trimmedName.toLowerCase())) {
-      res.status(400).json({
-        message: 'That page name is reserved by the API for special use cases.'
-      })
-    } else {
-      Page.findById(req.params.id).exec(function (err, page) {
-        if (err) {
-          res.status(500).json({
-            message: err.message
-          })
-        } else if (page) {
-          if (page.name !== trimmedName) {
-            res.status(400).json({
-              message: 'Page renaming is not yet implemented.'
-            })
-          } else {
-            page.body = (body && body.trim()) || ''
-            page.edited = new Date()
-            page.save(function (err, saved) {
-              if (err) {
-                res.status(500).json({
-                  message: err.message
-                })
-              } else if (saved) {
-                res.status(200).json(saved)
-              }
-            })
-          }
-        } else {
-          res.status(404).json({
-            message: 'Page not found.'
-          })
-        }
+    if (!page) {
+      return res.status(404).json({
+        message: 'Page not found.'
       })
     }
-  } else {
-    res.status(400).json({
-      message: 'Page name is required.'
+
+    if (parent !== page.parent) {
+      if (parent !== undefined) {
+        if (page.system) {
+          return res.status(403).json({
+            message: 'System pages cannot be moved.'
+          })
+        } else if (parent === null) {
+          page.parent = parent
+        } else {
+          const parentPage = await Page.findById(parent)
+          if (parentPage) {
+            let ancestorCheck = parentPage
+            while (ancestorCheck) {
+              if (ancestorCheck._id === page._id) {
+                return res.status(400).json({
+                  message: 'Cannot set parent of requested page to a child of that page.'
+                })
+              }
+              ancestorCheck = ancestorCheck.parent ? await Page.findById(ancestorCheck.parent) : null
+            }
+            page.parent = parentPage
+          } else {
+            return res.status(404).json({
+              message: 'New parent page was not found.'
+            })
+          }
+        }
+      }
+    }
+
+    if (name) {
+      const trimmed = name.trim()
+      const slug = slugify(trimmed).toLowerCase()
+
+      if (slug !== page.slug) {
+        if (page.system) {
+          return res.status(403).json({
+            message: 'System pages cannot be renamed.'
+          })
+        } else {
+          const existingPage = await Page.findOne({
+            parent: page.parent,
+            $or: [
+              { slug },
+              { name: trimmed }
+            ]
+          })
+
+          if (existingPage) {
+            return res.status(400).json({
+              message: 'A page already exists with that name.'
+            })
+          } else {
+            page.name = trimmed
+            page.slug = slug
+          }
+        }
+      }
+    }
+
+    if (body && body.trim()) {
+      page.body = body
+      page.edited = new Date()
+
+      const saved = await page.save()
+
+      res.status(200).json(saved)
+    } else {
+      res.status(400).json({
+        message: 'Page body is required.'
+      })
+    }
+  } catch (err) {
+    res.status(500).json({
+      message: err.message
     })
   }
 })

--- a/server/routes/pages.js
+++ b/server/routes/pages.js
@@ -14,7 +14,7 @@ const reservedNames = [
 ]
 
 function moveChildren (page, moveTo, callback) {
-  function findNewHome(moveTo, callback) {
+  function findNewHome (moveTo, callback) {
     if (moveTo) {
       if (moveTo === page._id) {
         callback(new Error('Attempted to move children to where they already are.'), null)
@@ -229,7 +229,6 @@ router.post('/delete/:id', auth.owner, function (req, res) {
       })
     }
   })
-
 })
 
 router.get('/:id', function (req, res) {

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -7,6 +7,7 @@ const Comment = require('../models/comment')
 
 router.get('/:slug', function (req, res) {
   Post.findOne({ slug: req.params.slug })
+    .populate('category')
     .exec(function (err, post) {
       if (err) {
         res.status(500).json({
@@ -172,7 +173,7 @@ router.post('/:slug/delete', auth.admin, function (req, res) {
 })
 
 router.get('/', function (req, res) {
-  Post.find({}).exec(function (err, posts) {
+  Post.find({}).populate('category').exec(function (err, posts) {
     if(err) {
       res.status(500).json({
         message: err.message

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -1,9 +1,8 @@
 const express = require('express')
 const router = express.Router()
 const slugify = require('slugify')
-const Post = require('../models/post');
+const Post = require('../models/post')
 const auth = require('../middleware/auth')
-const Comment = require('../models/comment')
 const Category = require('../models/category')
 
 router.get('/:slug', function (req, res) {
@@ -25,35 +24,10 @@ router.get('/:slug', function (req, res) {
     })
 })
 
-router.get('/:slug/comments', function (req, res) {
-  const slug = req.params.slug
-  Post.findOne({ slug }).exec((err, post) => {
-    if (err) {
-      res.status(500).json({
-        message: err.message
-      })
-    } else if (post) {
-      Comment.find({ commentType: 'post', belongsTo: post._id }).populate('author').exec((err, comments) => {
-        if (err) {
-          res.status(500).json({
-            message: err.message
-          })
-        } else {
-          res.status(200).json(comments)
-        }
-      })
-    } else {
-      res.status(404).json({
-        message: 'Post not found.'
-      })
-    }
-  })
-})
-
 router.post('/:slug', auth.admin, function (req, res) {
   const { name, excerpt, body } = req.body
 
-  Post.findOne({ slug: req.params.slug }).exec(async function(err, post) {
+  Post.findOne({ slug: req.params.slug }).exec(async function (err, post) {
     try {
       if (err) {
         res.status(500).json({
@@ -106,55 +80,6 @@ router.post('/:slug', auth.admin, function (req, res) {
   })
 })
 
-router.post('/:slug/comments', auth.authenticate, function (req, res) {
-  const slug = req.params.slug
-  const commentBody = req.body.comment && req.body.comment.trim()
-
-  if (commentBody) {
-    Post.findOne({ slug }).exec((err, post) => {
-      if (err) {
-        res.status(500).json({
-          message: err.message
-        })
-      } else if (post) {
-        // TODO: A spam filter is definitely needed. Possibly start with duplicate prevention?
-        const comment = new Comment({
-          commentType: 'post',
-          author: req.user,
-          posted: new Date(),
-          body: commentBody,
-          belongsTo: post._id
-        })
-
-        comment.save((err, saved) => {
-          if (err) {
-            res.status(500).json({
-              message: err.message
-            })
-          } else if (saved) {
-            res.status(200).json({
-              comment: saved,
-              author: req.user
-            })
-          } else {
-            res.status(500).json({
-              message: 'Something weird just happened. That comment did not go through.'
-            })
-          }
-        })
-      } else {
-        res.status(404).json({
-          message: 'Post not found.'
-        })
-      }
-    })
-  } else {
-    res.status(400).json({
-      message: 'A non-whitespace comment body is required in the comment field.'
-    })
-  }
-})
-
 router.post('/:slug/delete', auth.admin, function (req, res) {
   const slug = req.params.slug
   Post.deleteOne({
@@ -176,7 +101,7 @@ router.post('/:slug/delete', auth.admin, function (req, res) {
 
 router.get('/', function (req, res) {
   Post.find({}).populate('category').populate('author').exec(function (err, posts) {
-    if(err) {
+    if (err) {
       res.status(500).json({
         message: err.message
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11030,6 +11030,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
+truncate@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/truncate/-/truncate-2.1.0.tgz#391183563a25cffbd4d613a1d00ae5844c9e55d3"
+  integrity sha512-em3E3SUDONOjTBcZ36DTm3RvDded3IRU9rX32oHwwXNt3rJD5MVaFlJTQvs8tJoHRoeYP36OuQ1eL/Q7bNEWIQ==
+
 try-catch@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/try-catch/-/try-catch-2.0.1.tgz#a35d354187c422f291a0bcfd9eb77e3a4f90c1e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2658,6 +2658,15 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
+clipboard@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.6.tgz#52921296eec0fdf77ead1749421b21c968647376"
+  integrity sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
@@ -3643,7 +3652,7 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3731,6 +3740,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
+  integrity sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -5088,6 +5102,13 @@ gonzales-pe@^4.2.3:
   dependencies:
     minimist "^1.2.5"
 
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  integrity sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=
+  dependencies:
+    delegate "^3.1.2"
+
 got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
@@ -5561,7 +5582,7 @@ import-modules@^2.0.0:
   resolved "https://registry.yarnpkg.com/import-modules/-/import-modules-2.0.0.tgz#9c1e13b4e7a15682f70a6e3fa29534e4540cfc5d"
   integrity sha512-iczM/v9drffdNnABOKwj0f9G3cFDon99VcG1mxeBsdqnbd+vnQ5c2uAiCHNQITqFTOPaEvwg3VjoWCur0uHLEw==
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -6586,11 +6607,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -6599,32 +6615,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -6700,11 +6694,6 @@ lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.snakecase@^4.1.1:
   version "4.1.1"
@@ -9117,6 +9106,13 @@ prism-es6@^1.2.0:
   resolved "https://registry.yarnpkg.com/prism-es6/-/prism-es6-1.2.0.tgz#ead4e0d7809fefc36b9636f1ea4b2cebad074e63"
   integrity sha512-A8JV9G2zKM8PWksT7YJcmnaWtYO6C9hSfxM/xv0RxB2aNc8rjv30WakzIw1gWyqLi2eiqquo2KmS7orxqlm+yg==
 
+prismjs@^1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.20.0.tgz#9b685fc480a3514ee7198eac6a3bf5024319ff03"
+  integrity sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==
+  optionalDependencies:
+    clipboard "^2.0.0"
+
 private@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -9977,6 +9973,11 @@ scrollparent@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/scrollparent/-/scrollparent-2.0.1.tgz#715d5b9cc57760fb22bdccc3befb5bfe06b1a317"
   integrity sha1-cV1bnMV3YPsivczDvvtb/gaxoxc=
+
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+  integrity sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=
 
 semver-diff@^2.0.0:
   version "2.1.0"
@@ -10924,6 +10925,11 @@ timsort@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
+
+tiny-emitter@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
 tiny-relative-date@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
This change completely overhauls the various editor UIs that admins get. (Quick Editor, Page Editor, Post Editor) to make them more simple and elegant. There are also some general bugfixes.

 - Quick Editor now has a Cancel button and a Full Editor button.
 - Quick Editor dialog now takes up less of the screen space on desktop.
 - Post Editor has been redesigned.
 - Page Editor has been redesigned.
 - It is now possible to edit a blog post after it has been published.
 - It is now possible to rename a blog post after it has been published.
 - Quick Editor no longer directly edits the `value` prop when you click "Save".
 - Markdown editor has been rewritten, no longer uses `vuetify-markdown-editor`.
 - A badge is now displayed on all system pages in Administration -> Pages.
 - System pages can no longer be renamed, moved, or deleted.
 - Error pages now display correctly.
 - Code syntax highlighting has been fixed. 

### TODO

 - [x] Make it possible to create categories and set the category of a blog post.
 - [x] Allow listing of all blog posts in a given category.
 - [x] Display 5 other category posts in the side-bar of a blog post.
 - [x] Display Markdown content of the blog system page in the blog UI.
 - [x] Allow renaming of Pages.
 - [x] Support for YouTube video embeds in Posts and Pages.
 - [x] Overhaul the layout of Comments.
 - [x] Allow users to reply to Comments.